### PR TITLE
Transition to Rust 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   include:
     # This is the minimum Rust version supported by auto_enums.
     # When updating this, the reminder to update the minimum required version in README.md.
-    - rust: 1.30.0
+    - rust: 1.31.0
 
     - rust: stable
     - rust: beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,6 @@ matrix:
     #     - cargo test --all-features -p auto_enums -p auto_enums_core -p auto_enums_derive
 
     - rust: nightly
-      name: cargo test (2018 edition)
-      script:
-        - cd "${TRAVIS_BUILD_DIR}/test_suite/tests_2018"
-        - cargo test --all-features
-
-    - rust: nightly
       name: cargo clippy
       script:
         - if rustup component add clippy-preview;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Transition to Rust 2018. With this change, the minimum required version will go up to Rust 1.31.
+
+* Reduce the feature of "std" crate feature. The current "std" crate feature only determines whether to enable `std` library's traits (e.g., `std::io::Read`) support. "std" crate feature is enabled by default, but you can reduce compile time by disabling this feature.
+
 # 0.4.1 - 2019-02-21
 
 * Update to new nightly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Reduce the feature of "std" crate feature. The current "std" crate feature only determines whether to enable `std` library's traits (e.g., `std::io::Read`) support. "std" crate feature is enabled by default, but you can reduce compile time by disabling this feature.
 
+* Remove "unstable" crate feature.
+
 # 0.4.1 - 2019-02-21
 
 * Update to new nightly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "auto_enums"
 # NB: When modifying, also modify html_root_url in lib.rs
 version = "0.4.1"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
 license = "Apache-2.0/MIT"
 description = "A library for to allow multiple return types by automatically generated enum."
 repository = "https://github.com/taiki-e/auto_enums"
@@ -39,7 +40,7 @@ default = ["std"]
 # Analyze return type of function and `let` binding.
 type_analysis = ["auto_enums_core/type_analysis"]
 
-# Use `transpose*` methods.
+# Enable to use `transpose*` methods.
 transpose_methods = ["auto_enums_derive/transpose_methods"]
 
 # Make `?` operator support more flexible, and to make iterator implementation more effective.
@@ -51,10 +52,9 @@ unstable = ["auto_enums_core/unstable", "auto_enums_derive/unstable"]
 # =============================================================================
 # [std|core] libraries
 
-# Use `std` library.
+# Enable to use `std` library's traits.
 std = ["auto_enums_derive/std"]
-
-# Use `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write`
+# Enable to use `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write`
 fmt = ["auto_enums_derive/fmt"]
 
 # Enable unstable features of [std|core] libraries.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "core",
     "derive",
     "test_suite",
+    "test_suite/tests_unstable",
 ]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ transpose_methods = ["auto_enums_derive/transpose_methods"]
 # Make `?` operator support more flexible, and to make iterator implementation more effective.
 try_trait = ["auto_enums_core/try_trait", "auto_enums_derive/try_trait"]
 
-# Use unstable features to make attribute macro more effective.
-unstable = ["auto_enums_core/unstable", "auto_enums_derive/unstable"]
-
 # =============================================================================
 # [std|core] libraries
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![version](https://img.shields.io/crates/v/auto_enums.svg)](https://crates.io/crates/auto_enums/)
 [![documentation](https://docs.rs/auto_enums/badge.svg)](https://docs.rs/auto_enums/)
 [![license](https://img.shields.io/crates/l/auto_enums.svg)](https://crates.io/crates/auto_enums/)
-[![Rustc Version](https://img.shields.io/badge/rustc-1.30+-lightgray.svg)](https://blog.rust-lang.org/2018/10/25/Rust-1.30.0.html)
+[![Rustc Version](https://img.shields.io/badge/rustc-1.31+-lightgray.svg)](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html)
 
 A library for to allow multiple return types by automatically generated enum.
 
@@ -132,13 +132,13 @@ Note that some traits have aliases.
 
 * [`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html) (alias: `fmt::Debug`) - [generated code](docs/supported_traits/std/debug.md)
 * [`Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) (alias: `fmt::Display`)
-* [`fmt::Binary`](https://doc.rust-lang.org/std/fmt/trait.Binary.html) (*requires `"fmt"` crate feature*)
-* [`fmt::LowerExp`](https://doc.rust-lang.org/std/fmt/trait.LowerExp.html) (*requires `"fmt"` crate feature*)
-* [`fmt::LowerHex`](https://doc.rust-lang.org/std/fmt/trait.LowerHex.html) (*requires `"fmt"` crate feature*)
-* [`fmt::Octal`](https://doc.rust-lang.org/std/fmt/trait.Octal.html) (*requires `"fmt"` crate feature*)
-* [`fmt::Pointer`](https://doc.rust-lang.org/std/fmt/trait.Pointer.html) (*requires `"fmt"` crate feature*)
-* [`fmt::UpperExp`](https://doc.rust-lang.org/std/fmt/trait.UpperExp.html) (*requires `"fmt"` crate feature*)
-* [`fmt::UpperHex`](https://doc.rust-lang.org/std/fmt/trait.UpperHex.html) (*requires `"fmt"` crate feature*)
+* [`fmt::Binary`](https://doc.rust-lang.org/std/fmt/trait.Binary.html) *(requires `"fmt"` crate feature)*
+* [`fmt::LowerExp`](https://doc.rust-lang.org/std/fmt/trait.LowerExp.html) *(requires `"fmt"` crate feature)*
+* [`fmt::LowerHex`](https://doc.rust-lang.org/std/fmt/trait.LowerHex.html) *(requires `"fmt"` crate feature)*
+* [`fmt::Octal`](https://doc.rust-lang.org/std/fmt/trait.Octal.html) *(requires `"fmt"` crate feature)*
+* [`fmt::Pointer`](https://doc.rust-lang.org/std/fmt/trait.Pointer.html) *(requires `"fmt"` crate feature)*
+* [`fmt::UpperExp`](https://doc.rust-lang.org/std/fmt/trait.UpperExp.html) *(requires `"fmt"` crate feature)*
+* [`fmt::UpperHex`](https://doc.rust-lang.org/std/fmt/trait.UpperHex.html) *(requires `"fmt"` crate feature)*
 * [`fmt::Write`](https://doc.rust-lang.org/std/fmt/trait.Write.html)
 
 `[std|core]::future`
@@ -160,36 +160,36 @@ Note that some traits have aliases.
 
 You can add support for external library by activating the each crate feature.
 
-[`futures(v0.3)`](https://github.com/rust-lang-nursery/futures-rs) (*requires `"futures"` crate feature*)
+[`futures(v0.3)`](https://github.com/rust-lang-nursery/futures-rs) *(requires `"futures"` crate feature)*
 
 * [`futures::Stream`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures/stream/trait.Stream.html) - [generated code](docs/supported_traits/external/futures/stream.md)
 * [`futures::Sink`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures/sink/trait.Sink.html) - [generated code](docs/supported_traits/external/futures/sink.md)
 * [`futures::AsyncRead`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures/io/trait.AsyncRead.html) - [generated code](docs/supported_traits/external/futures/async_read.md)
 * [`futures::AsyncWrite`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures/io/trait.AsyncWrite.html) - [generated code](docs/supported_traits/external/futures/async_write.md)
 
-[`futures(v0.1)`](https://github.com/rust-lang-nursery/futures-rs) (*requires `"futures01"` crate feature*)
+[`futures(v0.1)`](https://github.com/rust-lang-nursery/futures-rs) *(requires `"futures01"` crate feature)*
 
 * [`futures01::Future`](https://docs.rs/futures/0.1/futures/future/trait.Future.html)
 * [`futures01::Stream`](https://docs.rs/futures/0.1/futures/stream/trait.Stream.html)
 * [`futures01::Sink`](https://docs.rs/futures/0.1/futures/sink/trait.Sink.html)
 
-[`quote`](https://github.com/dtolnay/quote) (*requires `"proc_macro"` crate feature*)
+[`quote`](https://github.com/dtolnay/quote) *(requires `"proc_macro"` crate feature)*
 
 * [`quote::ToTokens`](https://docs.rs/quote/0.6/quote/trait.ToTokens.html)
 
-[`rayon`](https://github.com/rayon-rs/rayon) (*requires `"rayon"` crate feature*)
+[`rayon`](https://github.com/rayon-rs/rayon) *(requires `"rayon"` crate feature)*
 
 * [`rayon::ParallelIterator`](https://docs.rs/rayon/1.0/rayon/iter/trait.ParallelIterator.html)
 * [`rayon::IndexedParallelIterator`](https://docs.rs/rayon/1.0/rayon/iter/trait.IndexedParallelIterator.html)
 * [`rayon::ParallelExtend`](https://docs.rs/rayon/1.0/rayon/iter/trait.ParallelExtend.html)
 
-[`serde`](https://github.com/serde-rs/serde) (*requires `"serde"` crate feature*)
+[`serde`](https://github.com/serde-rs/serde) *(requires `"serde"` crate feature)*
 
 * [`serde::Serialize`](https://docs.serde.rs/serde/trait.Serialize.html) - [generated code](docs/supported_traits/external/serde/serialize.md)
 
 ## Rust Version
 
-The current minimum required Rust version is 1.30.
+The current minimum required Rust version is 1.31.
 
 ## License
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,6 +3,7 @@ name = "auto_enums_core"
 # NB: When modifying, also modify html_root_url in lib.rs
 version = "0.4.1"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
 license = "Apache-2.0/MIT"
 description = "This library provides an attribute macro for to allow multiple return types by automatically generated enum."
 repository = "https://github.com/taiki-e/auto_enums"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,8 +32,5 @@ default = []
 # Analyze return type of function and `let` binding.
 type_analysis = []
 
-# Use unstable features to make attribute macro more effective.
-unstable = ["smallvec/union", "smallvec/may_dangle"]
-
 # Make `?` operator support more flexible.
 try_trait = []

--- a/core/src/attribute/attrs.rs
+++ b/core/src/attribute/attrs.rs
@@ -32,17 +32,17 @@ pub(super) trait AttrsMut: Attrs {
     }
 }
 
-impl<'a, A: Attrs> Attrs for &'a A {
+impl<A: Attrs> Attrs for &'_ A {
     fn attrs(&self) -> &[Attribute] {
         (**self).attrs()
     }
 }
-impl<'a, A: Attrs> Attrs for &'a mut A {
+impl<A: Attrs> Attrs for &'_ mut A {
     fn attrs(&self) -> &[Attribute] {
         (**self).attrs()
     }
 }
-impl<'a, A: AttrsMut> AttrsMut for &'a mut A {
+impl<A: AttrsMut> AttrsMut for &'_ mut A {
     fn attrs_mut<T, F: FnOnce(&mut Vec<Attribute>) -> T>(&mut self, f: F) -> T {
         (**self).attrs_mut(f)
     }

--- a/core/src/attribute/expr.rs
+++ b/core/src/attribute/expr.rs
@@ -277,7 +277,7 @@ impl<'a> LoopVisitor<'a> {
     }
 }
 
-impl<'a> VisitMut for LoopVisitor<'a> {
+impl VisitMut for LoopVisitor<'_> {
     fn visit_expr_mut(&mut self, expr: &mut Expr) {
         if expr.any_empty_attr(NEVER_ATTR) {
             return;

--- a/core/src/attribute/traits.rs
+++ b/core/src/attribute/traits.rs
@@ -42,7 +42,7 @@ impl<'a> ImplTraits<'a> {
     }
 }
 
-impl<'a> VisitMut for ImplTraits<'a> {
+impl VisitMut for ImplTraits<'_> {
     fn visit_type_impl_trait_mut(&mut self, ty: &mut TypeImplTrait) {
         visit_mut::visit_type_impl_trait_mut(self, ty);
 

--- a/core/src/attribute/visitor.rs
+++ b/core/src/attribute/visitor.rs
@@ -159,20 +159,18 @@ impl<'a> Visitor<'a> {
                     #[cfg(feature = "try_trait")]
                     {
                         parse_quote! {{
-                            extern crate core;
-                            match core::ops::Try::into_result(#expr) {
-                                core::result::Result::Ok(val) => val,
-                                core::result::Result::Err(err) => return core::ops::Try::from_error(#err),
+                            match ::core::ops::Try::into_result(#expr) {
+                                ::core::result::Result::Ok(val) => val,
+                                ::core::result::Result::Err(err) => return ::core::ops::Try::from_error(#err),
                             }
                         }}
                     }
                     #[cfg(not(feature = "try_trait"))]
                     {
                         parse_quote! {{
-                            extern crate core;
                             match #expr {
-                                core::result::Result::Ok(val) => val,
-                                core::result::Result::Err(err) => return core::result::Result::Err(#err),
+                                ::core::result::Result::Ok(val) => val,
+                                ::core::result::Result::Err(err) => return ::core::result::Result::Err(#err),
                             }
                         }}
                     }
@@ -228,7 +226,7 @@ impl Tmp {
     }
 }
 
-impl<'a> VisitMut for Visitor<'a> {
+impl VisitMut for Visitor<'_> {
     fn visit_expr_mut(&mut self, expr: &mut Expr) {
         let tmp = Tmp::store(self);
         self.other_attr(expr);
@@ -304,7 +302,7 @@ impl<'a> FindTry<'a> {
     }
 }
 
-impl<'a> VisitMut for FindTry<'a> {
+impl VisitMut for FindTry<'_> {
     fn visit_expr_mut(&mut self, expr: &mut Expr) {
         let tmp_in_closure = self.in_closure;
         let tmp_foreign = self.foreign;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,14 +2,10 @@
 #![recursion_limit = "256"]
 #![doc(html_root_url = "https://docs.rs/auto_enums_core/0.4.1")]
 #![deny(unsafe_code)]
-#![deny(bare_trait_objects, elided_lifetimes_in_paths)]
+#![deny(rust_2018_idioms)]
+#![deny(unreachable_pub)]
 
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate quote;
-extern crate rand;
-extern crate smallvec;
-extern crate syn;
 
 #[macro_use]
 mod utils;

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "auto_enums_derive"
 # NB: When modifying, also modify html_root_url in lib.rs
 version = "0.4.1"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
 license = "Apache-2.0/MIT"
 description = "This library provides an attribute macro like a wrapper of `#[derive]`, implementing the supported traits and passing unsupported traits to `#[derive]`."
 repository = "https://github.com/taiki-e/auto_enums"
@@ -38,9 +39,8 @@ unstable = ["smallvec/union", "smallvec/may_dangle"]
 # =============================================================================
 # [std|core] libraries
 
-# Use `std` library.
+# Use `std` library's traits.
 std = []
-
 # Use `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write`
 fmt = []
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -33,9 +33,6 @@ default = ["std"]
 # Use conversion methods.
 transpose_methods = []
 
-# Use unstable features to make attribute macro more effective.
-unstable = ["smallvec/union", "smallvec/may_dangle"]
-
 # =============================================================================
 # [std|core] libraries
 

--- a/derive/src/derive/external/futures/async_read.rs
+++ b/derive/src/derive/external/futures/async_read.rs
@@ -5,7 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["futures::AsyncRead"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
     let io = quote!(::futures::io);
 
     derive_trait!(
@@ -18,15 +17,15 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 #[inline]
                 fn poll_read(
                     &mut self,
-                    waker: &#root::task::Waker,
+                    waker: &::core::task::Waker,
                     buf: &mut [u8],
-                ) -> #root::task::Poll<#root::result::Result<usize, #io::Error>>;
+                ) -> ::core::task::Poll<::core::result::Result<usize, #io::Error>>;
                 #[inline]
                 fn poll_vectored_read(
                     &mut self,
-                    waker: &#root::task::Waker,
+                    waker: &::core::task::Waker,
                     vec: &mut [&mut #io::IoVec],
-                ) -> #root::task::Poll<#root::result::Result<usize, #io::Error>>;
+                ) -> ::core::task::Poll<::core::result::Result<usize, #io::Error>>;
             }
         }?,
     )

--- a/derive/src/derive/external/futures/async_write.rs
+++ b/derive/src/derive/external/futures/async_write.rs
@@ -5,7 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["futures::AsyncWrite"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
     let io = quote!(::futures::io);
 
     derive_trait!(
@@ -16,25 +15,25 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 #[inline]
                 fn poll_write(
                     &mut self,
-                    waker: &#root::task::Waker,
+                    waker: &::core::task::Waker,
                     buf: &[u8],
-                ) -> #root::task::Poll<#root::result::Result<usize, #io::Error>>;
+                ) -> ::core::task::Poll<::core::result::Result<usize, #io::Error>>;
                 #[inline]
                 fn poll_vectored_write(
                     &mut self,
-                    waker: &#root::task::Waker,
+                    waker: &::core::task::Waker,
                     vec: &[&#io::IoVec],
-                ) -> #root::task::Poll<#root::result::Result<usize, #io::Error>>;
+                ) -> ::core::task::Poll<::core::result::Result<usize, #io::Error>>;
                 #[inline]
                 fn poll_flush(
                     &mut self,
-                    waker: &#root::task::Waker,
-                ) -> #root::task::Poll<#root::result::Result<(), #io::Error>>;
+                    waker: &::core::task::Waker,
+                ) -> ::core::task::Poll<::core::result::Result<(), #io::Error>>;
                 #[inline]
                 fn poll_close(
                     &mut self,
-                    waker: &#root::task::Waker,
-                ) -> #root::task::Poll<#root::result::Result<(), #io::Error>>;
+                    waker: &::core::task::Waker,
+                ) -> ::core::task::Poll<::core::result::Result<(), #io::Error>>;
             }
         }?,
     )

--- a/derive/src/derive/external/futures/sink.rs
+++ b/derive/src/derive/external/futures/sink.rs
@@ -5,8 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["futures::Sink"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
         parse_quote!(::futures::sink::Sink)?,
@@ -16,24 +14,24 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 type SinkError;
                 #[inline]
                 fn poll_ready(
-                    self: #root::pin::Pin<&mut Self>,
-                    waker: &#root::task::Waker,
-                ) -> #root::task::Poll<#root::result::Result<(), Self::SinkError>>;
+                    self: ::core::pin::Pin<&mut Self>,
+                    waker: &::core::task::Waker,
+                ) -> ::core::task::Poll<::core::result::Result<(), Self::SinkError>>;
                 #[inline]
                 fn start_send(
-                    self: #root::pin::Pin<&mut Self>,
+                    self: ::core::pin::Pin<&mut Self>,
                     item: Self::SinkItem,
-                ) -> #root::result::Result<(), Self::SinkError>;
+                ) -> ::core::result::Result<(), Self::SinkError>;
                 #[inline]
                 fn poll_flush(
-                    self: #root::pin::Pin<&mut Self>,
-                    waker: &#root::task::Waker,
-                ) -> #root::task::Poll<#root::result::Result<(), Self::SinkError>>;
+                    self: ::core::pin::Pin<&mut Self>,
+                    waker: &::core::task::Waker,
+                ) -> ::core::task::Poll<::core::result::Result<(), Self::SinkError>>;
                 #[inline]
                 fn poll_close(
-                    self: #root::pin::Pin<&mut Self>,
-                    waker: &#root::task::Waker,
-                ) -> #root::task::Poll<#root::result::Result<(), Self::SinkError>>;
+                    self: ::core::pin::Pin<&mut Self>,
+                    waker: &::core::task::Waker,
+                ) -> ::core::task::Poll<::core::result::Result<(), Self::SinkError>>;
             }
         }?,
     )

--- a/derive/src/derive/external/futures/stream.rs
+++ b/derive/src/derive/external/futures/stream.rs
@@ -5,8 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["futures::Stream"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
         parse_quote!(::futures::stream::Stream)?,
@@ -15,9 +13,9 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 type Item;
                 #[inline]
                 fn poll_next(
-                    self: #root::pin::Pin<&mut Self>,
-                    waker: &#root::task::Waker,
-                ) -> #root::task::Poll<#root::option::Option<Self::Item>>;
+                    self: ::core::pin::Pin<&mut Self>,
+                    waker: &::core::task::Waker,
+                ) -> ::core::task::Poll<::core::option::Option<Self::Item>>;
             }
         }?,
     )

--- a/derive/src/derive/external/futures01/stream.rs
+++ b/derive/src/derive/external/futures01/stream.rs
@@ -5,7 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["futures01::Stream"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
     let crate_ = quote!(::futures);
 
     derive_trait!(
@@ -16,7 +15,7 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 type Item;
                 type Error;
                 #[inline]
-                fn poll(&mut self) -> #crate_::Poll<#root::option::Option<Self::Item>, Self::Error>;
+                fn poll(&mut self) -> #crate_::Poll<::core::option::Option<Self::Item>, Self::Error>;
             }
         }?,
     )

--- a/derive/src/derive/external/rayon/par_iter.rs
+++ b/derive/src/derive/external/rayon/par_iter.rs
@@ -5,7 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["rayon::ParallelIterator"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
     let iter = quote!(::rayon::iter);
 
     derive_trait!(
@@ -19,7 +18,7 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 where
                     __C: #iter::plumbing::UnindexedConsumer<Self::Item>;
                 #[inline]
-                fn opt_len(&self) -> #root::option::Option<usize>;
+                fn opt_len(&self) -> ::core::option::Option<usize>;
             }
         }?,
     )

--- a/derive/src/derive/external/serde/serialize.rs
+++ b/derive/src/derive/external/serde/serialize.rs
@@ -5,7 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["serde::Serialize"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
     let ser = quote!(::serde::ser);
 
     derive_trait!(
@@ -14,7 +13,7 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
         parse_quote! {
             trait Serialize {
                 #[inline]
-                fn serialize<__S>(&self, serializer: __S) -> #root::result::Result<__S::Ok, __S::Error>
+                fn serialize<__S>(&self, serializer: __S) -> ::core::result::Result<__S::Ok, __S::Error>
                 where
                     __S: #ser::Serializer;
             }

--- a/derive/src/derive/std/convert/as_mut.rs
+++ b/derive/src/derive/std/convert/as_mut.rs
@@ -5,11 +5,9 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["AsMut"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
-        parse_quote!(#root::convert::AsMut)?,
+        parse_quote!(::core::convert::AsMut)?,
         parse_quote! {
             trait AsMut<__T: ?Sized> {
                 #[inline]

--- a/derive/src/derive/std/convert/as_ref.rs
+++ b/derive/src/derive/std/convert/as_ref.rs
@@ -5,11 +5,9 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["AsRef"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
-        parse_quote!(#root::convert::AsRef)?,
+        parse_quote!(::core::convert::AsRef)?,
         parse_quote! {
             trait AsRef<__T: ?Sized> {
                 #[inline]

--- a/derive/src/derive/std/error.rs
+++ b/derive/src/derive/std/error.rs
@@ -5,24 +5,21 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Error"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let trait_ = parse_quote!(#root::error::Error)?;
-
     let ident = data.ident();
     let source = data
         .variants()
         .iter()
-        .map(|v| quote!(#ident::#v(x) => #root::option::Option::Some(x)));
+        .map(|v| quote!(#ident::#v(x) => ::std::option::Option::Some(x)));
 
     let source = parse_quote! {
-        fn source(&self) -> #root::option::Option<&(dyn (#trait_) + 'static)> {
+        fn source(&self) -> ::std::option::Option<&(dyn (::std::error::Error) + 'static)> {
             match self { #(#source,)* }
         }
     }?;
 
     let mut impls = data.impl_trait_with_capacity(
         2,
-        trait_,
+        parse_quote!(::std::error::Error)?,
         None,
         parse_quote! {
             trait Error {

--- a/derive/src/derive/std/fmt/mod.rs
+++ b/derive/src/derive/std/fmt/mod.rs
@@ -8,8 +8,7 @@ macro_rules! fmt_impl {
             pub(crate) const NAME: &[&str] = &[$($name),*];
 
             pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-                let root = std_root();
-                let fmt = quote!(#root::fmt);
+                let fmt = quote!(::core::fmt);
 
                 derive_trait!(
                     data,

--- a/derive/src/derive/std/fmt/write.rs
+++ b/derive/src/derive/std/fmt/write.rs
@@ -5,8 +5,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["fmt::Write"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let fmt = quote!(#root::fmt);
+    let fmt = quote!(::core::fmt);
 
     derive_trait!(
         data,

--- a/derive/src/derive/std/future.rs
+++ b/derive/src/derive/std/future.rs
@@ -5,19 +5,17 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Future"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
-        parse_quote!(#root::future::Future)?,
+        parse_quote!(::core::future::Future)?,
         parse_quote! {
             trait Future {
                 type Output;
                 #[inline]
                 fn poll(
-                    self: #root::pin::Pin<&mut Self>,
-                    waker: &#root::task::Waker
-                ) -> #root::task::Poll<Self::Output>;
+                    self: ::core::pin::Pin<&mut Self>,
+                    waker: &::core::task::Waker
+                ) -> ::core::task::Poll<Self::Output>;
             }
         }?,
     )

--- a/derive/src/derive/std/io/buf_read.rs
+++ b/derive/src/derive/std/io/buf_read.rs
@@ -5,8 +5,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["BufRead", "io::BufRead"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let io = quote!(#root::io);
+    let io = quote!(::std::io);
 
     derive_trait!(
         data,
@@ -18,9 +17,9 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 #[inline]
                 fn consume(&mut self, amt: usize);
                 #[inline]
-                fn read_until(&mut self, byte: u8, buf: &mut #root::vec::Vec<u8>) -> #io::Result<usize>;
+                fn read_until(&mut self, byte: u8, buf: &mut ::std::vec::Vec<u8>) -> #io::Result<usize>;
                 #[inline]
-                fn read_line(&mut self, buf: &mut #root::string::String) -> #io::Result<usize>;
+                fn read_line(&mut self, buf: &mut ::std::string::String) -> #io::Result<usize>;
             }
         }?,
     )

--- a/derive/src/derive/std/io/read.rs
+++ b/derive/src/derive/std/io/read.rs
@@ -5,8 +5,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Read", "io::Read"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let io = quote!(#root::io);
+    let io = quote!(::std::io);
 
     #[cfg(not(feature = "read_initializer"))]
     let initializer = TokenStream::new();
@@ -24,9 +23,9 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 #[inline]
                 fn read(&mut self, buf: &mut [u8]) -> #io::Result<usize>;
                 #[inline]
-                fn read_to_end(&mut self, buf: &mut #root::vec::Vec<u8>) -> #io::Result<usize>;
+                fn read_to_end(&mut self, buf: &mut ::std::vec::Vec<u8>) -> #io::Result<usize>;
                 #[inline]
-                fn read_to_string(&mut self, buf: &mut #root::string::String) -> #io::Result<usize>;
+                fn read_to_string(&mut self, buf: &mut ::std::string::String) -> #io::Result<usize>;
                 #[inline]
                 fn read_exact(&mut self, buf: &mut [u8]) -> #io::Result<()>;
                 #initializer

--- a/derive/src/derive/std/io/seek.rs
+++ b/derive/src/derive/std/io/seek.rs
@@ -5,8 +5,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Seek", "io::Seek"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let io = quote!(#root::io);
+    let io = quote!(::std::io);
 
     derive_trait!(
         data,

--- a/derive/src/derive/std/io/write.rs
+++ b/derive/src/derive/std/io/write.rs
@@ -5,8 +5,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Write", "io::Write"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let io = quote!(#root::io);
+    let io = quote!(::std::io);
 
     derive_trait!(
         data,
@@ -20,7 +19,7 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
                 #[inline]
                 fn write_all(&mut self, buf: &[u8]) -> #io::Result<()>;
                 #[inline]
-                fn write_fmt(&mut self, fmt: #root::fmt::Arguments) -> #io::Result<()>;
+                fn write_fmt(&mut self, fmt: ::std::fmt::Arguments) -> #io::Result<()>;
             }
         }?,
     )

--- a/derive/src/derive/std/iter/double_ended_iterator.rs
+++ b/derive/src/derive/std/iter/double_ended_iterator.rs
@@ -5,15 +5,13 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["DoubleEndedIterator"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     #[cfg(feature = "try_trait")]
     let try_trait = quote! {
         #[inline]
         fn try_rfold<__U, __F, __R>(&mut self, init: __U, f: __F) -> __R
         where
-            __F: #root::ops::FnMut(__U, Self::Item) -> __R,
-            __R: #root::ops::Try<Ok = __U>;
+            __F: ::core::ops::FnMut(__U, Self::Item) -> __R,
+            __R: ::core::ops::Try<Ok = __U>;
     };
     // It is equally efficient if `try_rfold` can be used.
     #[cfg(not(feature = "try_trait"))]
@@ -21,21 +19,21 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
         #[inline]
         fn rfold<__U, __F>(self, accum: __U, f: __F) -> __U
         where
-            __F: #root::ops::FnMut(__U, Self::Item) -> __U;
+            __F: ::core::ops::FnMut(__U, Self::Item) -> __U;
         #[inline]
-        fn rfind<__P>(&mut self, predicate: __P) -> #root::option::Option<Self::Item>
+        fn rfind<__P>(&mut self, predicate: __P) -> ::core::option::Option<Self::Item>
         where
-            __P: #root::ops::FnMut(&Self::Item) -> bool;
+            __P: ::core::ops::FnMut(&Self::Item) -> bool;
     };
 
     derive_trait!(
         data,
         Some(ident_call_site("Item")),
-        parse_quote!(#root::iter::DoubleEndedIterator)?,
+        parse_quote!(::core::iter::DoubleEndedIterator)?,
         parse_quote! {
-            trait DoubleEndedIterator: #root::iter::Iterator {
+            trait DoubleEndedIterator: ::core::iter::Iterator {
                 #[inline]
-                fn next_back(&mut self) -> #root::option::Option<Self::Item>;
+                fn next_back(&mut self) -> ::core::option::Option<Self::Item>;
                 #try_trait
             }
         }?,

--- a/derive/src/derive/std/iter/exact_size_iterator.rs
+++ b/derive/src/derive/std/iter/exact_size_iterator.rs
@@ -5,8 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["ExactSizeIterator"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     #[cfg(not(feature = "exact_size_is_empty"))]
     let is_empty = TokenStream::new();
     #[cfg(feature = "exact_size_is_empty")]
@@ -18,9 +16,9 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
     derive_trait!(
         data,
         Some(ident_call_site("Item")),
-        parse_quote!(#root::iter::ExactSizeIterator)?,
+        parse_quote!(::core::iter::ExactSizeIterator)?,
         parse_quote! {
-            trait ExactSizeIterator: #root::iter::Iterator {
+            trait ExactSizeIterator: ::core::iter::Iterator {
                 #[inline]
                 fn len(&self) -> usize;
                 #is_empty

--- a/derive/src/derive/std/iter/extend.rs
+++ b/derive/src/derive/std/iter/extend.rs
@@ -5,15 +5,13 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Extend"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
-        parse_quote!(#root::iter::Extend)?,
+        parse_quote!(::core::iter::Extend)?,
         parse_quote! {
             trait Extend<__A> {
                 #[inline]
-                fn extend<__T: #root::iter::IntoIterator<Item = __A>>(&mut self, iter: __T);
+                fn extend<__T: ::core::iter::IntoIterator<Item = __A>>(&mut self, iter: __T);
             }
         }?,
     )

--- a/derive/src/derive/std/iter/fused_iterator.rs
+++ b/derive/src/derive/std/iter/fused_iterator.rs
@@ -5,14 +5,12 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["FusedIterator"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
         Some(ident_call_site("Item")),
-        parse_quote!(#root::iter::FusedIterator)?,
+        parse_quote!(::core::iter::FusedIterator)?,
         parse_quote! {
-            trait FusedIterator: #root::iter::Iterator {}
+            trait FusedIterator: ::core::iter::Iterator {}
         }?,
     )
 }

--- a/derive/src/derive/std/iter/iterator.rs
+++ b/derive/src/derive/std/iter/iterator.rs
@@ -5,15 +5,13 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Iterator"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     #[cfg(feature = "try_trait")]
     let try_trait = quote! {
         #[inline]
         fn try_fold<__U, __F, __R>(&mut self, init: __U, f: __F) -> __R
         where
-            __F: #root::ops::FnMut(__U, Self::Item) -> __R,
-            __R: #root::ops::Try<Ok = __U>;
+            __F: ::core::ops::FnMut(__U, Self::Item) -> __R,
+            __R: ::core::ops::Try<Ok = __U>;
     };
     // It is equally efficient if `try_fold` can be used.
     #[cfg(not(feature = "try_trait"))]
@@ -21,53 +19,53 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
         #[inline]
         fn fold<__U, __F>(self, init: __U, f: __F) -> __U
         where
-            __F: #root::ops::FnMut(__U, Self::Item) -> __U;
+            __F: ::core::ops::FnMut(__U, Self::Item) -> __U;
         #[inline]
         fn all<__F>(&mut self, f: __F) -> bool
         where
-            __F: #root::ops::FnMut(Self::Item) -> bool;
+            __F: ::core::ops::FnMut(Self::Item) -> bool;
         #[inline]
         fn any<__F>(&mut self, f: __F) -> bool
         where
-            __F: #root::ops::FnMut(Self::Item) -> bool;
+            __F: ::core::ops::FnMut(Self::Item) -> bool;
         #[inline]
-        fn find<__P>(&mut self, predicate: __P) -> #root::option::Option<Self::Item>
+        fn find<__P>(&mut self, predicate: __P) -> ::core::option::Option<Self::Item>
         where
-            __P: #root::ops::FnMut(&Self::Item) -> bool;
+            __P: ::core::ops::FnMut(&Self::Item) -> bool;
         #[inline]
-        fn find_map<__U, __F>(&mut self, f: __F) -> #root::option::Option<__U>
+        fn find_map<__U, __F>(&mut self, f: __F) -> ::core::option::Option<__U>
         where
-            __F: #root::ops::FnMut(Self::Item) -> #root::option::Option<__U>;
+            __F: ::core::ops::FnMut(Self::Item) -> ::core::option::Option<__U>;
         #[inline]
-        fn position<__P>(&mut self, predicate: __P) -> #root::option::Option<usize>
+        fn position<__P>(&mut self, predicate: __P) -> ::core::option::Option<usize>
         where
-            __P: #root::ops::FnMut(Self::Item) -> bool;
+            __P: ::core::ops::FnMut(Self::Item) -> bool;
     };
 
     derive_trait!(
         data,
-        parse_quote!(#root::iter::Iterator)?,
+        parse_quote!(::core::iter::Iterator)?,
         parse_quote! {
             trait Iterator {
                 type Item;
                 #[inline]
-                fn next(&mut self) -> #root::option::Option<Self::Item>;
+                fn next(&mut self) -> ::core::option::Option<Self::Item>;
                 #[inline]
-                fn size_hint(&self) -> (usize, #root::option::Option<usize>);
+                fn size_hint(&self) -> (usize, ::core::option::Option<usize>);
                 #[inline]
                 fn count(self) -> usize;
                 #[inline]
-                fn last(self) -> #root::option::Option<Self::Item>;
+                fn last(self) -> ::core::option::Option<Self::Item>;
                 #[inline]
-                fn nth(&mut self, n: usize) -> #root::option::Option<Self::Item>;
+                fn nth(&mut self, n: usize) -> ::core::option::Option<Self::Item>;
                 #[inline]
                 #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
-                fn collect<__U: #root::iter::FromIterator<Self::Item>>(self) -> __U;
+                fn collect<__U: ::core::iter::FromIterator<Self::Item>>(self) -> __U;
                 #[inline]
                 fn partition<__U, __F>(self, f: __F) -> (__U, __U)
                 where
-                    __U: #root::default::Default + #root::iter::Extend<Self::Item>,
-                    __F: #root::ops::FnMut(&Self::Item) -> bool;
+                    __U: ::core::default::Default + ::core::iter::Extend<Self::Item>,
+                    __F: ::core::ops::FnMut(&Self::Item) -> bool;
                 #try_trait
             }
         }?,

--- a/derive/src/derive/std/iter/trusted_len.rs
+++ b/derive/src/derive/std/iter/trusted_len.rs
@@ -5,14 +5,12 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["TrustedLen"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
         Some(ident_call_site("Item")),
-        parse_quote!(#root::iter::TrustedLen)?,
+        parse_quote!(::core::iter::TrustedLen)?,
         parse_quote! {
-            unsafe trait TrustedLen: #root::iter::Iterator {}
+            unsafe trait TrustedLen: ::core::iter::Iterator {}
         }?,
     )
 }

--- a/derive/src/derive/std/ops/deref.rs
+++ b/derive/src/derive/std/ops/deref.rs
@@ -5,11 +5,9 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Deref"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
-        parse_quote!(#root::ops::Deref)?,
+        parse_quote!(::core::ops::Deref)?,
         parse_quote! {
             trait Deref {
                 type Target;

--- a/derive/src/derive/std/ops/deref_mut.rs
+++ b/derive/src/derive/std/ops/deref_mut.rs
@@ -5,14 +5,12 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["DerefMut"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
         Some(ident_call_site("Target")),
-        parse_quote!(#root::ops::DerefMut)?,
+        parse_quote!(::core::ops::DerefMut)?,
         parse_quote! {
-            trait DerefMut: #root::ops::Deref {
+            trait DerefMut: ::core::ops::Deref {
                 #[inline]
                 fn deref_mut(&mut self) -> &mut Self::Target;
             }

--- a/derive/src/derive/std/ops/fn_.rs
+++ b/derive/src/derive/std/ops/fn_.rs
@@ -5,8 +5,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Fn"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let trait_path = quote!(#root::ops::Fn);
+    let trait_path = quote!(::core::ops::Fn);
     let trait_ = quote!(#trait_path(__T) -> __U);
     let fst = data.fields().iter().next();
 

--- a/derive/src/derive/std/ops/fn_mut.rs
+++ b/derive/src/derive/std/ops/fn_mut.rs
@@ -5,8 +5,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["FnMut"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let trait_path = quote!(#root::ops::FnMut);
+    let trait_path = quote!(::core::ops::FnMut);
     let trait_ = quote!(#trait_path(__T) -> __U);
     let fst = data.fields().iter().next();
 

--- a/derive/src/derive/std/ops/fn_once.rs
+++ b/derive/src/derive/std/ops/fn_once.rs
@@ -5,8 +5,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["FnOnce"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-    let trait_path = quote!(#root::ops::FnOnce);
+    let trait_path = quote!(::core::ops::FnOnce);
     let trait_ = quote!(#trait_path(__T) -> __U);
     let fst = data.fields().iter().next();
 

--- a/derive/src/derive/std/ops/generator.rs
+++ b/derive/src/derive/std/ops/generator.rs
@@ -5,17 +5,15 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Generator"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
-        parse_quote!(#root::ops::Generator)?,
+        parse_quote!(::core::ops::Generator)?,
         parse_quote! {
             trait Generator {
                 type Yield;
                 type Return;
                 #[inline]
-                fn resume(self: #root::pin::Pin<&mut Self>) -> #root::ops::GeneratorState<Self::Yield, Self::Return>;
+                fn resume(self: ::core::pin::Pin<&mut Self>) -> ::core::ops::GeneratorState<Self::Yield, Self::Return>;
             }
         }?,
     )

--- a/derive/src/derive/std/ops/index.rs
+++ b/derive/src/derive/std/ops/index.rs
@@ -5,8 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Index"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     #[cfg(not(feature = "unsized_locals"))]
     let bounds = TokenStream::new();
     #[cfg(feature = "unsized_locals")]
@@ -14,7 +12,7 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
 
     derive_trait!(
         data,
-        parse_quote!(#root::ops::Index)?,
+        parse_quote!(::core::ops::Index)?,
         parse_quote! {
             trait Index<__Idx #bounds> {
                 type Output;

--- a/derive/src/derive/std/ops/index_mut.rs
+++ b/derive/src/derive/std/ops/index_mut.rs
@@ -5,8 +5,6 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["IndexMut"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     #[cfg(not(feature = "unsized_locals"))]
     let bounds = TokenStream::new();
     #[cfg(feature = "unsized_locals")]
@@ -15,9 +13,9 @@ pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
     derive_trait!(
         data,
         Some(ident_call_site("Output")),
-        parse_quote!(#root::ops::IndexMut)?,
+        parse_quote!(::core::ops::IndexMut)?,
         parse_quote! {
-            trait IndexMut<__Idx #bounds>: #root::ops::Index<__Idx> {
+            trait IndexMut<__Idx #bounds>: ::core::ops::Index<__Idx> {
                 #[inline]
                 fn index_mut(&mut self, index: __Idx) -> &mut Self::Output;
             }

--- a/derive/src/derive/std/ops/range_bounds.rs
+++ b/derive/src/derive/std/ops/range_bounds.rs
@@ -5,17 +5,15 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["RangeBounds"];
 
 pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
-    let root = std_root();
-
     derive_trait!(
         data,
-        parse_quote!(#root::ops::RangeBounds)?,
+        parse_quote!(::core::ops::RangeBounds)?,
         parse_quote! {
             trait RangeBounds<__T: ?Sized> {
                 #[inline]
-                fn start_bound(&self) -> #root::ops::Bound<&__T>;
+                fn start_bound(&self) -> ::core::ops::Bound<&__T>;
                 #[inline]
-                fn end_bound(&self) -> #root::ops::Bound<&__T>;
+                fn end_bound(&self) -> ::core::ops::Bound<&__T>;
             }
         }?,
     )

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -2,15 +2,10 @@
 #![recursion_limit = "256"]
 #![doc(html_root_url = "https://docs.rs/auto_enums_derive/0.4.1")]
 #![deny(unsafe_code)]
-#![deny(bare_trait_objects, elided_lifetimes_in_paths)]
+#![deny(rust_2018_idioms)]
+#![deny(unreachable_pub)]
 
-extern crate derive_utils;
-extern crate lazy_static;
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate quote;
-extern crate smallvec;
-extern crate syn;
 
 #[macro_use]
 mod utils;

--- a/derive/src/utils/mod.rs
+++ b/derive/src/utils/mod.rs
@@ -1,9 +1,10 @@
-use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro2::{Ident, Span};
 use smallvec::SmallVec;
 use syn::{punctuated::Punctuated, *};
 
 pub(crate) use derive_utils::{Error, Result, *};
 pub(crate) use quote::{quote, ToTokens};
+pub(crate) use syn::parse2;
 
 pub(crate) type Data = EnumData;
 pub(crate) type Stack<T> = SmallVec<[T; 4]>;
@@ -23,21 +24,9 @@ pub(crate) fn param_ident(ident: &str) -> GenericParam {
     })
 }
 
-/// Returns standard library's root.
-///
-/// In default returns `::std`.
-/// if disabled default crate feature, returned `::core`.
-pub(crate) fn std_root() -> TokenStream {
-    #[cfg(feature = "std")]
-    let root = quote!(::std);
-    #[cfg(not(feature = "std"))]
-    let root = quote!(::core);
-    root
-}
-
 macro_rules! parse_quote {
     ($($tt:tt)*) => {
-        $crate::syn::parse2($crate::quote::quote!($($tt)*))
+        $crate::utils::parse2($crate::utils::quote!($($tt)*))
     };
 }
 

--- a/docs/example-1.md
+++ b/docs/example-1.md
@@ -5,21 +5,21 @@ fn foo(x: i32) -> impl Iterator<Item = i32> {
         __T2(__T2),
     }
 
-    impl<__T1, __T2> ::std::iter::Iterator for __Enum1<__T1, __T2>
+    impl<__T1, __T2> ::core::iter::Iterator for __Enum1<__T1, __T2>
     where
-        __T1: ::std::iter::Iterator,
-        __T2: ::std::iter::Iterator<Item = <__T1 as ::std::iter::Iterator>::Item>,
+        __T1: ::core::iter::Iterator,
+        __T2: ::core::iter::Iterator<Item = <__T1 as ::core::iter::Iterator>::Item>,
     {
-        type Item = <__T1 as ::std::iter::Iterator>::Item;
+        type Item = <__T1 as ::core::iter::Iterator>::Item;
         #[inline]
-        fn next(&mut self) -> ::std::option::Option<Self::Item> {
+        fn next(&mut self) -> ::core::option::Option<Self::Item> {
             match self {
                 __Enum1::__T1(x) => x.next(),
                 __Enum1::__T2(x) => x.next(),
             }
         }
         #[inline]
-        fn size_hint(&self) -> (usize, ::std::option::Option<usize>) {
+        fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
             match self {
                 __Enum1::__T1(x) => x.size_hint(),
                 __Enum1::__T2(x) => x.size_hint(),

--- a/docs/supported_traits/external/serde/serialize.md
+++ b/docs/supported_traits/external/serde/serialize.md
@@ -12,8 +12,6 @@ enum Enum<A, B> {
 
 Code like this will be generated:
 
-*If `std` crate feature is disabled, `::std` is replaced with `::core`.*
-
 Note that it is a different implementation from `#[derive(Serialize)]`.
 
 ```rust

--- a/docs/supported_traits/std/debug.md
+++ b/docs/supported_traits/std/debug.md
@@ -12,8 +12,6 @@ enum Enum<A, B> {
 
 Code like this will be generated:
 
-*If `std` crate feature is disabled, `::std` is replaced with `::core`.*
-
 Note that it is a different implementation from `#[derive(Debug)]`.
 
 ```rust
@@ -22,15 +20,15 @@ enum Enum<A, B> {
     B(B),
 }
 
-impl<A, B> ::std::fmt::Debug for Enum<A, B>
+impl<A, B> ::core::fmt::Debug for Enum<A, B>
 where
-    A: ::std::fmt::Debug,
-    B: ::std::fmt::Debug,
+    A: ::core::fmt::Debug,
+    B: ::core::fmt::Debug,
 {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         match self {
-            Enum::A(x) => ::std::fmt::Debug::fmt(x, f),
-            Enum::B(x) => ::std::fmt::Debug::fmt(x, f),
+            Enum::A(x) => ::core::fmt::Debug::fmt(x, f),
+            Enum::B(x) => ::core::fmt::Debug::fmt(x, f),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -817,12 +817,6 @@
 //!   * Make `?` operator support more flexible, and to make iterator implementation more effective.
 //!   * This requires Rust Nightly and you need to enable the unstable [`try_trait`](https://github.com/rust-lang/rust/issues/42327) feature gate.
 //!
-//! * `unstable`
-//!   * Disabled by default.
-//!   * Use unstable features to make attribute macros more effective.
-//!   * The traits supported by `#[enum_derive]` are **not** related to this feature.
-//!   * This requires Rust Nightly.
-//!
 //! ### Using external libraries (disabled by default)
 //!
 //! * `futures` - [futures(v0.3)](https://github.com/rust-lang-nursery/futures-rs)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,21 +71,21 @@
 //!         __T2(__T2),
 //!     }
 //!
-//!     impl<__T1, __T2> ::std::iter::Iterator for __Enum1<__T1, __T2>
+//!     impl<__T1, __T2> ::core::iter::Iterator for __Enum1<__T1, __T2>
 //!     where
-//!         __T1: ::std::iter::Iterator,
-//!         __T2: ::std::iter::Iterator<Item = <__T1 as ::std::iter::Iterator>::Item>,
+//!         __T1: ::core::iter::Iterator,
+//!         __T2: ::core::iter::Iterator<Item = <__T1 as ::core::iter::Iterator>::Item>,
 //!     {
-//!         type Item = <__T1 as ::std::iter::Iterator>::Item;
+//!         type Item = <__T1 as ::core::iter::Iterator>::Item;
 //!         #[inline]
-//!         fn next(&mut self) -> ::std::option::Option<Self::Item> {
+//!         fn next(&mut self) -> ::core::option::Option<Self::Item> {
 //!             match self {
 //!                 __Enum1::__T1(x) => x.next(),
 //!                 __Enum1::__T2(x) => x.next(),
 //!             }
 //!         }
 //!         #[inline]
-//!         fn size_hint(&self) -> (usize, ::std::option::Option<usize>) {
+//!         fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
 //!             match self {
 //!                 __Enum1::__T1(x) => x.size_hint(),
 //!                 __Enum1::__T2(x) => x.size_hint(),
@@ -679,27 +679,27 @@
 //!
 //! * [`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html) (alias: `fmt::Debug`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/debug.md)
 //! * [`Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) (alias: `fmt::Display`)
-//! * [`fmt::Binary`](https://doc.rust-lang.org/std/fmt/trait.Binary.html)
-//! * [`fmt::LowerExp`](https://doc.rust-lang.org/std/fmt/trait.LowerExp.html)
-//! * [`fmt::LowerHex`](https://doc.rust-lang.org/std/fmt/trait.LowerHex.html)
-//! * [`fmt::Octal`](https://doc.rust-lang.org/std/fmt/trait.Octal.html)
-//! * [`fmt::Pointer`](https://doc.rust-lang.org/std/fmt/trait.Pointer.html)
-//! * [`fmt::UpperExp`](https://doc.rust-lang.org/std/fmt/trait.UpperExp.html)
-//! * [`fmt::UpperHex`](https://doc.rust-lang.org/std/fmt/trait.UpperHex.html)
+//! * [`fmt::Binary`](https://doc.rust-lang.org/std/fmt/trait.Binary.html) *(requires `"fmt"` crate feature)*
+//! * [`fmt::LowerExp`](https://doc.rust-lang.org/std/fmt/trait.LowerExp.html) *(requires `"fmt"` crate feature)*
+//! * [`fmt::LowerHex`](https://doc.rust-lang.org/std/fmt/trait.LowerHex.html) *(requires `"fmt"` crate feature)*
+//! * [`fmt::Octal`](https://doc.rust-lang.org/std/fmt/trait.Octal.html) *(requires `"fmt"` crate feature)*
+//! * [`fmt::Pointer`](https://doc.rust-lang.org/std/fmt/trait.Pointer.html) *(requires `"fmt"` crate feature)*
+//! * [`fmt::UpperExp`](https://doc.rust-lang.org/std/fmt/trait.UpperExp.html) *(requires `"fmt"` crate feature)*
+//! * [`fmt::UpperHex`](https://doc.rust-lang.org/std/fmt/trait.UpperHex.html) *(requires `"fmt"` crate feature)*
 //! * [`fmt::Write`](https://doc.rust-lang.org/std/fmt/trait.Write.html)
 //!
 //! `[std|core]::future`
 //!
 //! * [`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) - *nightly-only* - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/future.md)
 //!
-//! `std::io`
+//! `std::io` *(requires `"std"` crate feature)*
 //!
 //! * [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) (alias: `io::Read`)
 //! * [`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) (alias: `io::BufRead`)
 //! * [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) (alias: `io::Write`)
 //! * [`Seek`](https://doc.rust-lang.org/std/io/trait.Seek.html) (alias: `io::Seek`)
 //!
-//! `std::error`
+//! `std::error` *(requires `"std"` crate feature)*
 //!
 //! * [`Error`](https://doc.rust-lang.org/std/error/trait.Error.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/error.md)
 //!
@@ -707,30 +707,30 @@
 //!
 //! You can add support for external library by activating the each crate feature.
 //!
-//! [`futures(v0.3)`](https://github.com/rust-lang-nursery/futures-rs) (*requires `"futures"` crate feature*)
+//! [`futures(v0.3)`](https://github.com/rust-lang-nursery/futures-rs) *(requires `"futures"` crate feature)*
 //!
 //! * [`futures::Stream`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures/stream/trait.Stream.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/external/futures/stream.md)
 //! * [`futures::Sink`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures/sink/trait.Sink.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/external/futures/sink.md)
 //! * [`futures::AsyncRead`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures/io/trait.AsyncRead.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/external/futures/async_read.md)
 //! * [`futures::AsyncWrite`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures/io/trait.AsyncWrite.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/external/futures/async_write.md)
 //!
-//! [`futures(v0.1)`](https://github.com/rust-lang-nursery/futures-rs) (*requires `"futures01"` crate feature*)
+//! [`futures(v0.1)`](https://github.com/rust-lang-nursery/futures-rs) *(requires `"futures01"` crate feature)*
 //!
 //! * [`futures01::Future`](https://docs.rs/futures/0.1/futures/future/trait.Future.html)
 //! * [`futures01::Stream`](https://docs.rs/futures/0.1/futures/stream/trait.Stream.html)
 //! * [`futures01::Sink`](https://docs.rs/futures/0.1/futures/sink/trait.Sink.html)
 //!
-//! [`quote`](https://github.com/dtolnay/quote) (*requires `"proc_macro"` crate feature*)
+//! [`quote`](https://github.com/dtolnay/quote) *(requires `"proc_macro"` crate feature)*
 //!
 //! * [`quote::ToTokens`](https://docs.rs/quote/0.6/quote/trait.ToTokens.html)
 //!
-//! [`rayon`](https://github.com/rayon-rs/rayon) (*requires `"rayon"` crate feature*)
+//! [`rayon`](https://github.com/rayon-rs/rayon) *(requires `"rayon"` crate feature)*
 //!
 //! * [`rayon::ParallelIterator`](https://docs.rs/rayon/1.0/rayon/iter/trait.ParallelIterator.html)
 //! * [`rayon::IndexedParallelIterator`](https://docs.rs/rayon/1.0/rayon/iter/trait.IndexedParallelIterator.html)
 //! * [`rayon::ParallelExtend`](https://docs.rs/rayon/1.0/rayon/iter/trait.ParallelExtend.html)
 //!
-//! [`serde`](https://github.com/serde-rs/serde) (*requires `"serde"` crate feature*)
+//! [`serde`](https://github.com/serde-rs/serde) *(requires `"serde"` crate feature)*
 //!
 //! * [`serde::Serialize`](https://docs.serde.rs/serde/trait.Serialize.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/external/serde/serialize.md)
 //!
@@ -738,7 +738,7 @@
 //!
 //! These don't derive traits, but derive static methods instead.
 //!
-//! * `Transpose` (*requires `"transpose_methods"` crate feature*) - this derives the following conversion methods.
+//! * `Transpose` *(requires `"transpose_methods"` crate feature)* - this derives the following conversion methods.
 //!
 //!   * `transpose` - convert from `enum<Option<T1>,..>` to `Option<enum<T1,..>>`
 //!
@@ -775,12 +775,11 @@
 //!
 //! * `std`
 //!   * Enabled by default.
-//!   * Generate code for `std` library.
-//!   * Disable this feature to generate code for `no_std`.
+//!   * Enable to use `std` library's traits.
 //!
 //! * `fmt`
 //!   * Disabled by default.
-//!   * Use `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write`.
+//!   * Enable to use `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write`.
 //!
 //! * `type_analysis`
 //!   * Disabled by default.
@@ -811,7 +810,7 @@
 //!
 //! * `transpose_methods`
 //!   * Disabled by default.
-//!   * Use `transpose*` methods.
+//!   * Enable to use `transpose*` methods.
 //!
 //! * `try_trait`
 //!   * Disabled by default.
@@ -858,9 +857,6 @@
 #![recursion_limit = "256"]
 #![doc(html_root_url = "https://docs.rs/auto_enums/0.4.1")]
 #![no_std]
-
-extern crate auto_enums_core;
-extern crate auto_enums_derive;
 
 #[doc(hidden)]
 pub use auto_enums_core::auto_enum;

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -2,6 +2,7 @@
 name = "auto_enums_test_suite"
 version = "0.0.0"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -39,7 +39,6 @@ external_libraries = [
 ]
 
 unstable = [
-    "auto_enums/unstable",
     "auto_enums/read_initializer",
     "auto_enums/exact_size_is_empty",
     "auto_enums/try_trait",

--- a/test_suite/tests/test_auto_enum.rs
+++ b/test_suite/tests/test_auto_enum.rs
@@ -20,13 +20,10 @@
 #![cfg_attr(all(not(feature = "std"), feature = "unstable"), feature(alloc))]
 #![deny(warnings)]
 #![allow(unused_imports)]
-#![cfg(test)]
 
 #[cfg(all(not(feature = "std"), feature = "unstable"))]
 #[macro_use]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate core;
 
 #[macro_use]
 extern crate auto_enums;

--- a/test_suite/tests/test_enum_derive.rs
+++ b/test_suite/tests/test_enum_derive.rs
@@ -19,21 +19,9 @@
 #![deny(warnings)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
-#![cfg(test)]
 
 #[cfg(all(not(feature = "std"), feature = "unstable"))]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate core;
-
-#[cfg(feature = "external_libraries")]
-extern crate futures;
-#[cfg(feature = "external_libraries")]
-extern crate quote;
-#[cfg(feature = "external_libraries")]
-extern crate rayon;
-#[cfg(feature = "external_libraries")]
-extern crate serde;
 
 #[macro_use]
 extern crate auto_enums;

--- a/test_suite/tests_2018/Cargo.toml
+++ b/test_suite/tests_2018/Cargo.toml
@@ -18,7 +18,6 @@ features = ["std"]
 [features]
 unstable = [
     "futures-preview",
-    "auto_enums/unstable",
     "auto_enums/futures",
     "auto_enums/read_initializer",
     "auto_enums/exact_size_is_empty",

--- a/test_suite/tests_unstable/Cargo.toml
+++ b/test_suite/tests_unstable/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
-name = "auto_enums_tests_2018"
+name = "auto_enums_tests_unstable"
 version = "0.0.0"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 publish = false
-
-[workspace]
 
 [dependencies]
 futures-preview = { version = "=0.3.0-alpha.13", optional = true }

--- a/test_suite/tests_unstable/tests/test.rs
+++ b/test_suite/tests_unstable/tests/test.rs
@@ -15,7 +15,6 @@
 )]
 #![deny(warnings)]
 #![allow(unused_imports)]
-#![cfg(test)]
 
 #[macro_use]
 extern crate auto_enums;
@@ -65,7 +64,6 @@ mod test_futures {
     }
 }
 
-#[cfg(test)]
 mod enum_derive {
     #![allow(dead_code)]
 


### PR DESCRIPTION
* Transition to Rust 2018. With this change, the minimum required version will go up to Rust 1.31.

* Reduce the feature of "std" crate feature. The current "std" crate feature only determines whether to enable `std` library's traits (e.g., `std::io::Read`) support. "std" crate feature is enabled by default, but you can reduce compile time by disabling this feature.

* Remove "unstable" crate feature.

Closes #8 