### PR TITLE
Replace rand::rngs::ThreadRng with rand_xorshift::XorShiftRng

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,24 @@ matrix:
         - cd "${TRAVIS_BUILD_DIR}/test_suite"
         - cargo test --no-default-features
 
-    # rand does not correspond to a build with -Zminimal-versions.
-    # - rust: nightly
-    #   name: cargo test (minimal versions)
-    #   script:
-    #     - cargo update -Zminimal-versions
-    #     - cargo test --all-features -p auto_enums -p auto_enums_core -p auto_enums_derive
+    - rust: nightly
+      name: cargo test (minimal versions)
+      script:
+        - cargo update -Zminimal-versions
+        - cargo test --all-features -p auto_enums -p auto_enums_core -p auto_enums_derive
+
+    - rust: nightly
+      name: cargo tree
+      script:
+        - if [[ ! -x "$(command -v cargo-tree)" ]]; then
+            cargo install --debug cargo-tree || exit 1;
+          fi
+        - cargo update
+        - cargo tree
+        - cargo tree --duplicate
+        - cargo update -Zminimal-versions
+        - cargo tree
+        - cargo tree --duplicate
 
     - rust: nightly
       name: cargo clippy

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,9 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "^0.4.13"
 quote = "^0.6.8"
-rand = "^0.6.1"
+# It may be unnecessary if the next version of rand_xorshift is released.
+rand_core = ">=0.3.1, <0.5" # See https://github.com/rust-random/rand/issues/645
+rand_xorshift = "^0.1.1"
 smallvec = "^0.6.9"
 syn = { version = "^0.15.22", features = ["full", "visit-mut", "extra-traits"] }
 

--- a/core/src/attribute/builder.rs
+++ b/core/src/attribute/builder.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 
 use proc_macro2::Ident;
 use quote::quote;
-use rand::{rngs::ThreadRng, Rng};
 use smallvec::{smallvec, SmallVec};
 use syn::{Attribute, Expr, ExprCall, ExprPath, ItemEnum, Path};
 
@@ -11,7 +10,7 @@ use crate::utils::{Result, *};
 use super::Arg;
 
 thread_local! {
-    static RNG: RefCell<ThreadRng> = RefCell::new(rand::thread_rng());
+    static RNG: RefCell<XorShiftRng> = RefCell::new(xorshift_rng());
 }
 
 pub(super) type Builder = EnumBuilder;

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -7,7 +7,10 @@ use syn::{punctuated::Punctuated, *};
 #[macro_use]
 mod error;
 
+mod rand;
+
 pub(crate) use self::error::{Error, Result, *};
+pub(crate) use self::rand::*;
 
 pub(crate) type Stack<T> = SmallVec<[T; 4]>;
 

--- a/core/src/utils/rand.rs
+++ b/core/src/utils/rand.rs
@@ -1,0 +1,50 @@
+use rand_core::{RngCore, SeedableRng};
+
+// =============================================================================
+// XorShiftRng
+
+pub(crate) use rand_xorshift::XorShiftRng;
+
+pub(crate) fn xorshift_rng() -> XorShiftRng {
+    const SEED: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    XorShiftRng::from_seed(SEED)
+}
+
+// =============================================================================
+// Rng
+
+pub(crate) trait Rng: RngCore {
+    #[inline]
+    fn gen<T>(&mut self) -> T
+    where
+        Standard: Distribution<T>,
+    {
+        Standard.sample(self)
+    }
+}
+
+impl<R: RngCore + ?Sized> Rng for R {}
+
+// =============================================================================
+// Distribution
+
+pub(crate) trait Distribution<T> {
+    /// Generate a random value of `T`, using `rng` as the source of randomness.
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> T;
+}
+
+impl<T, D: Distribution<T>> Distribution<T> for &'_ D {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> T {
+        (*self).sample(rng)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Standard;
+
+impl Distribution<u32> for Standard {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u32 {
+        rng.next_u32()
+    }
+}


### PR DESCRIPTION
In the current implementation, the generated enum is either defined on top of the new block or defined at the top of the function, so the possibility of name conflict is low.