### PR TITLE
Make more traits support optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Renamed `#[rec]` to `#[nested]`.
 
+* Added `"ops"` crate feature, and made `[std|core]::ops`'s `Deref`, `DerefMut`, `Index`, `IndexMut`, and `RangeBounds` traits optional.
+
+* Added `"convert"` crate feature, and made `[std|core]::convert`'s `AsRef` and `AsMut` traits optional.
+
 * Improved error messages.
 
 * Updated minimum `derive_utils` version to 0.8.0. This improves the error message.
@@ -140,7 +144,7 @@
 
 * Added support for `return` in function and closure.
 
-* Added `"fmt"` crate feature. Made `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write` optional.
+* Added `"fmt"` crate feature, and made `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write` optional.
 
 # 0.1.3 - 2018-12-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,12 @@ try_trait = ["auto_enums_core/try_trait", "auto_enums_derive/try_trait"]
 # Enable to use `std` library's traits.
 std = ["auto_enums_derive/std"]
 
+# Enable to use `[std|core]::ops`'s `Deref`, `DerefMut`, `Index`, `IndexMut`, and `RangeBounds` traits.
+ops = ["auto_enums_derive/ops"]
+
+# Enable to use `[std|core]::convert`'s `AsRef` and `AsMut` traits.
+convert = ["auto_enums_derive/convert"]
+
 # Enable to use `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write`
 fmt = ["auto_enums_derive/fmt"]
 

--- a/README.md
+++ b/README.md
@@ -113,23 +113,7 @@ enum Foo<A, B> {
 ### [std|core] libraries
 
 Note that some traits have aliases.
-
-`[std|core]::ops`
-
-* [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html)
-* [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html)
-* [`Index`](https://doc.rust-lang.org/std/ops/trait.Index.html)
-* [`IndexMut`](https://doc.rust-lang.org/std/ops/trait.IndexMut.html)
-* [`RangeBounds`](https://doc.rust-lang.org/std/ops/trait.RangeBounds.html)
-* [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html) (*nightly-only*)
-* [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) (*nightly-only*)
-* [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) (*nightly-only*)
-* [`Generator`](https://doc.rust-lang.org/nightly/std/ops/trait.Generator.html) (*nightly-only*)
-
-`[std|core]::convert`
-
-* [`AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html)
-* [`AsMut`](https://doc.rust-lang.org/std/convert/trait.AsMut.html)
+Also, some traits support is disabled by default.
 
 `[std|core]::iter`
 
@@ -139,6 +123,34 @@ Note that some traits have aliases.
 * [`FusedIterator`](https://doc.rust-lang.org/std/iter/trait.FusedIterator.html) - [generated code](docs/supported_traits/std/iter/fused_iterator.md)
 * [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html) - [generated code](docs/supported_traits/std/iter/trusted_len.md) (*nightly-only*)
 * [`Extend`](https://doc.rust-lang.org/std/iter/trait.Extend.html) - [generated code](docs/supported_traits/std/iter/extend.md)
+
+`[std|core]::future`
+
+* [`Future`](https://doc.rust-lang.org/nightly/std/future/trait.Future.html) - [generated code](docs/supported_traits/std/future.md)
+
+`std::io`
+
+* [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) (alias: `io::Read`) - [generated code](docs/supported_traits/std/io/read.md)
+* [`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) (alias: `io::BufRead`) - [generated code](docs/supported_traits/std/io/buf_read.md)
+* [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) (alias: `io::Write`) - [generated code](docs/supported_traits/std/io/write.md)
+* [`Seek`](https://doc.rust-lang.org/std/io/trait.Seek.html) (alias: `io::Seek`) - [generated code](docs/supported_traits/std/io/seek.md)
+
+`[std|core]::ops`
+
+* [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) *(requires `"ops"` crate feature)*
+* [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html) *(requires `"ops"` crate feature)*
+* [`Index`](https://doc.rust-lang.org/std/ops/trait.Index.html) *(requires `"ops"` crate feature)*
+* [`IndexMut`](https://doc.rust-lang.org/std/ops/trait.IndexMut.html) *(requires `"ops"` crate feature)*
+* [`RangeBounds`](https://doc.rust-lang.org/std/ops/trait.RangeBounds.html) *(requires `"ops"` crate feature)*
+* [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html) (*nightly-only*)
+* [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) (*nightly-only*)
+* [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) (*nightly-only*)
+* [`Generator`](https://doc.rust-lang.org/nightly/std/ops/trait.Generator.html) (*nightly-only*)
+
+`[std|core]::convert`
+
+* [`AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) *(requires `"convert"` crate feature)*
+* [`AsMut`](https://doc.rust-lang.org/std/convert/trait.AsMut.html) *(requires `"convert"` crate feature)*
 
 `[std|core]::fmt`
 
@@ -152,17 +164,6 @@ Note that some traits have aliases.
 * [`fmt::UpperExp`](https://doc.rust-lang.org/std/fmt/trait.UpperExp.html) *(requires `"fmt"` crate feature)*
 * [`fmt::UpperHex`](https://doc.rust-lang.org/std/fmt/trait.UpperHex.html) *(requires `"fmt"` crate feature)*
 * [`fmt::Write`](https://doc.rust-lang.org/std/fmt/trait.Write.html)
-
-`[std|core]::future`
-
-* [`Future`](https://doc.rust-lang.org/nightly/std/future/trait.Future.html) - [generated code](docs/supported_traits/std/future.md)
-
-`std::io`
-
-* [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) (alias: `io::Read`) - [generated code](docs/supported_traits/std/io/read.md)
-* [`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) (alias: `io::BufRead`) - [generated code](docs/supported_traits/std/io/buf_read.md)
-* [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) (alias: `io::Write`) - [generated code](docs/supported_traits/std/io/write.md)
-* [`Seek`](https://doc.rust-lang.org/std/io/trait.Seek.html) (alias: `io::Seek`) - [generated code](docs/supported_traits/std/io/seek.md)
 
 `std::error`
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -35,6 +35,12 @@ transpose_methods = []
 # Enable to use `std` library's traits.
 std = []
 
+# Enable to use `[std|core]::ops`'s `Deref`, `DerefMut`, `Index`, `IndexMut`, and `RangeBounds` traits.
+ops = []
+
+# Enable to use `[std|core]::convert`'s `AsRef` and `AsMut` traits.
+convert = []
+
 # Enable to use `[std|core]::fmt`'s traits other than `Debug`, `Display` and `Write`
 fmt = []
 

--- a/derive/src/derive/core/convert/mod.rs
+++ b/derive/src/derive/core/convert/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "convert")]
 pub(crate) mod as_mut;
+#[cfg(feature = "convert")]
 pub(crate) mod as_ref;

--- a/derive/src/derive/core/ops/mod.rs
+++ b/derive/src/derive/core/ops/mod.rs
@@ -1,9 +1,14 @@
+#[cfg(feature = "ops")]
 pub(crate) mod deref;
+#[cfg(feature = "ops")]
 pub(crate) mod deref_mut;
 pub(crate) mod fn_;
 pub(crate) mod fn_mut;
 pub(crate) mod fn_once;
 pub(crate) mod generator;
+#[cfg(feature = "ops")]
 pub(crate) mod index;
+#[cfg(feature = "ops")]
 pub(crate) mod index_mut;
+#[cfg(feature = "ops")]
 pub(crate) mod range_bounds;

--- a/derive/src/enum_derive.rs
+++ b/derive/src/enum_derive.rs
@@ -99,7 +99,9 @@ lazy_static! {
         derive_map!(
             map,
             // core
+            #[cfg(feature = "convert")]
             core::convert::as_mut,
+            #[cfg(feature = "convert")]
             core::convert::as_ref,
             core::fmt::debug,
             core::fmt::display,
@@ -124,10 +126,15 @@ lazy_static! {
             core::iter::fused_iterator,
             core::iter::trusted_len,
             core::iter::extend,
+            #[cfg(feature = "ops")]
             core::ops::deref,
+            #[cfg(feature = "ops")]
             core::ops::deref_mut,
+            #[cfg(feature = "ops")]
             core::ops::index,
+            #[cfg(feature = "ops")]
             core::ops::index_mut,
+            #[cfg(feature = "ops")]
             core::ops::range_bounds,
             core::ops::fn_,
             core::ops::fn_mut,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -653,23 +653,7 @@
 //! ### [std|core] libraries
 //!
 //! Note that some traits have aliases.
-//!
-//! `[std|core]::ops`
-//!
-//! * [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html)
-//! * [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html)
-//! * [`Index`](https://doc.rust-lang.org/std/ops/trait.Index.html)
-//! * [`IndexMut`](https://doc.rust-lang.org/std/ops/trait.IndexMut.html)
-//! * [`RangeBounds`](https://doc.rust-lang.org/std/ops/trait.RangeBounds.html)
-//! * [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html) (*nightly-only*)
-//! * [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) (*nightly-only*)
-//! * [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) (*nightly-only*)
-//! * [`Generator`](https://doc.rust-lang.org/nightly/std/ops/trait.Generator.html) (*nightly-only*)
-//!
-//! `[std|core]::convert`
-//!
-//! * [`AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html)
-//! * [`AsMut`](https://doc.rust-lang.org/std/convert/trait.AsMut.html)
+//! Also, some traits support is disabled by default.
 //!
 //! `[std|core]::iter`
 //!
@@ -679,6 +663,34 @@
 //! * [`FusedIterator`](https://doc.rust-lang.org/std/iter/trait.FusedIterator.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/iter/fused_iterator.md)
 //! * [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/iter/trusted_len.md) (*nightly-only*)
 //! * [`Extend`](https://doc.rust-lang.org/std/iter/trait.Extend.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/iter/extend.md)
+//!
+//! `[std|core]::future`
+//!
+//! * [`Future`](https://doc.rust-lang.org/nightly/std/future/trait.Future.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/future.md)
+//!
+//! `std::io` *(requires `"std"` crate feature)*
+//!
+//! * [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) (alias: `io::Read`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/io/read.md)
+//! * [`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) (alias: `io::BufRead`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/io/buf_read.md)
+//! * [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) (alias: `io::Write`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/io/write.md)
+//! * [`Seek`](https://doc.rust-lang.org/std/io/trait.Seek.html) (alias: `io::Seek`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/io/seek.md)
+//!
+//! `[std|core]::ops`
+//!
+//! * [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) *(requires `"ops"` crate feature)*
+//! * [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html) *(requires `"ops"` crate feature)*
+//! * [`Index`](https://doc.rust-lang.org/std/ops/trait.Index.html) *(requires `"ops"` crate feature)*
+//! * [`IndexMut`](https://doc.rust-lang.org/std/ops/trait.IndexMut.html) *(requires `"ops"` crate feature)*
+//! * [`RangeBounds`](https://doc.rust-lang.org/std/ops/trait.RangeBounds.html) *(requires `"ops"` crate feature)*
+//! * [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html) (*nightly-only*)
+//! * [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) (*nightly-only*)
+//! * [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) (*nightly-only*)
+//! * [`Generator`](https://doc.rust-lang.org/nightly/std/ops/trait.Generator.html) (*nightly-only*)
+//!
+//! `[std|core]::convert`
+//!
+//! * [`AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) *(requires `"convert"` crate feature)*
+//! * [`AsMut`](https://doc.rust-lang.org/std/convert/trait.AsMut.html) *(requires `"convert"` crate feature)*
 //!
 //! `[std|core]::fmt`
 //!
@@ -692,17 +704,6 @@
 //! * [`fmt::UpperExp`](https://doc.rust-lang.org/std/fmt/trait.UpperExp.html) *(requires `"fmt"` crate feature)*
 //! * [`fmt::UpperHex`](https://doc.rust-lang.org/std/fmt/trait.UpperHex.html) *(requires `"fmt"` crate feature)*
 //! * [`fmt::Write`](https://doc.rust-lang.org/std/fmt/trait.Write.html)
-//!
-//! `[std|core]::future`
-//!
-//! * [`Future`](https://doc.rust-lang.org/nightly/std/future/trait.Future.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/future.md)
-//!
-//! `std::io` *(requires `"std"` crate feature)*
-//!
-//! * [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) (alias: `io::Read`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/io/read.md)
-//! * [`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) (alias: `io::BufRead`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/io/buf_read.md)
-//! * [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) (alias: `io::Write`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/io/write.md)
-//! * [`Seek`](https://doc.rust-lang.org/std/io/trait.Seek.html) (alias: `io::Seek`) - [generated code](https://github.com/taiki-e/auto_enums/blob/master/docs/supported_traits/std/io/seek.md)
 //!
 //! `std::error` *(requires `"std"` crate feature)*
 //!
@@ -781,6 +782,14 @@
 //! * `std`
 //!   * Enabled by default.
 //!   * Enable to use `std` library's traits.
+//!
+//! * `ops`
+//!   * Disabled by default.
+//!   * Enable to use `[std|core]::ops`'s `Deref`, `DerefMut`, `Index`, `IndexMut`, and `RangeBounds` traits.
+//!
+//! * `convert`
+//!   * Disabled by default.
+//!   * Enable to use `[std|core]::convert`'s `AsRef` and `AsMut` traits.
 //!
 //! * `fmt`
 //!   * Disabled by default.

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,7 +12,7 @@ rayon = { version = "1.1", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-auto_enums = { path = "..", default-features = false, features = ["fmt", "transpose_methods"] }
+auto_enums = { path = "..", default-features = false, features = ["ops", "convert", "fmt", "transpose_methods"] }
 rand = "0.7"
 
 [features]


### PR DESCRIPTION
* Added `"ops"` crate feature, and made `[std|core]::ops`'s `Deref`, `DerefMut`, `Index`, `IndexMut`, and `RangeBounds` traits optional.

* Added `"convert"` crate feature, and made `[std|core]::convert`'s `AsRef` and `AsMut` traits optional.

Closes #42 