### PR TITLE
Remove never option in argument position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Renamed `#[rec]` to `#[nested]`.
 
+* [Removed `never` option in argument position in favor of `#[enum_derive]` attribute.][48]
+
 * Added `"ops"` crate feature, and made `[std|core]::ops`'s `Deref`, `DerefMut`, `Index`, `IndexMut`, and `RangeBounds` traits optional.
 
 * Added `"convert"` crate feature, and made `[std|core]::convert`'s `AsRef` and `AsMut` traits optional.
@@ -13,6 +15,8 @@
 * Added `"trusted_len"` crate feature, and made `[std|core]::iter::TrustedLen` traits optional. *(nightly-only)*
 
 * Improved error messages.
+
+[48]: https://github.com/taiki-e/auto_enums/pull/48
 
 # 0.5.10 - 2019-08-15
 

--- a/core/src/auto_enum/context.rs
+++ b/core/src/auto_enum/context.rs
@@ -42,7 +42,7 @@ pub(super) enum VisitLastMode {
     item_fn: `fn _() -> Fn*() { || {} }`
     */
     Closure,
-    /// `Stmt::Semi(..)` or `never` option - never visit last expr
+    /// `Stmt::Semi(..)` - never visit last expr
     Never,
 }
 
@@ -63,13 +63,7 @@ pub(super) struct Context {
 }
 
 impl Context {
-    fn new(
-        span: impl ToTokens,
-        args: Vec<Arg>,
-        marker: Option<String>,
-        never: bool,
-        root: bool,
-    ) -> Self {
+    fn new(span: impl ToTokens, args: Vec<Arg>, marker: Option<String>, root: bool) -> Self {
         Self {
             span: Some(span.into_token_stream()),
             args,
@@ -78,24 +72,18 @@ impl Context {
             // depth: 0,
             root,
             visit_mode: VisitMode::Default,
-            visit_last_mode: if never { VisitLastMode::Never } else { VisitLastMode::Default },
+            visit_last_mode: VisitLastMode::Default,
             other_attr: false,
             error: false,
         }
     }
 
-    pub(super) fn root(
-        span: impl ToTokens,
-        (args, marker, never): (Vec<Arg>, Option<String>, bool),
-    ) -> Self {
-        Self::new(span, args, marker, never, true)
+    pub(super) fn root(span: impl ToTokens, (args, marker): (Vec<Arg>, Option<String>)) -> Self {
+        Self::new(span, args, marker, true)
     }
 
-    pub(super) fn child(
-        span: impl ToTokens,
-        (args, marker, never): (Vec<Arg>, Option<String>, bool),
-    ) -> Self {
-        Self::new(span, args, marker, never, false)
+    pub(super) fn child(span: impl ToTokens, (args, marker): (Vec<Arg>, Option<String>)) -> Self {
+        Self::new(span, args, marker, false)
     }
 
     pub(super) fn span(&mut self) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,28 +469,6 @@
 //! # fn main() { let _ = foo(0); }
 //! ```
 //!
-//! You can also skip all branches by `never` option.
-//!
-//! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
-//! # use auto_enums::auto_enum;
-//! #[auto_enum(never, Iterator)]
-//! fn foo(x: i32) -> impl Iterator<Item = i32> {
-//!     match x {
-//!         0 => loop {
-//!             return marker!(1..10);
-//!         },
-//!         1 => loop {
-//!             panic!()
-//!         },
-//!         _ => loop {
-//!             return marker!(vec![5, 10].into_iter());
-//!         },
-//!     }
-//! }
-//! # fn main() { let _ = foo(0); }
-//! ```
-//!
 //! ### Expression level marker (`marker!` macro)
 //!
 //! `#[auto_enum]` replaces `marker!` macros with variants.

--- a/tests/auto_enum.rs
+++ b/tests/auto_enum.rs
@@ -647,19 +647,6 @@ fn nightly() {
         assert_eq!(iter.sum::<i32>(), *x);
     }
 
-    // never opt
-    for (i, x) in ANS.iter().enumerate() {
-        #[auto_enum(never, Iterator)]
-        let iter = match i {
-            0 => marker!(1..8),
-            5..=10 => loop {
-                panic!()
-            },
-            _ => marker!(vec![1, 2, 0].into_iter()),
-        };
-        assert_eq!(iter.sum::<i32>(), *x);
-    }
-
     // never attr
     for (i, x) in ANS.iter().enumerate() {
         #[rustfmt::skip]

--- a/tests/ui/auto_enum/args.rs
+++ b/tests/ui/auto_enum/args.rs
@@ -24,14 +24,6 @@ fn unexpected_token_2(x: usize) -> impl Iterator<Item = i32> {
 mod marker {
     use auto_enums::auto_enum;
 
-    #[auto_enum(never, never, Iterator)] //~ ERROR multiple `never` option
-    fn multiple_never(x: usize) -> impl Iterator<Item = i32> {
-        match x {
-            0 => 1..=8,
-            _ => 0..2,
-        }
-    }
-
     #[auto_enum(marker{f}, Iterator)] //~ ERROR invalid delimiter
     fn marker_invalid_delimiter_1(x: usize) -> impl Iterator<Item = i32> {
         match x {

--- a/tests/ui/auto_enum/args.stderr
+++ b/tests/ui/auto_enum/args.stderr
@@ -10,65 +10,59 @@ error: expected one of `,`, `::`, or identifier, found `;`
 16 | #[auto_enum(Iterator,;)] //~ ERROR expected one of `,`, `::`, or identifier, found `;`
    |                      ^
 
-error: multiple `never` option
-  --> $DIR/args.rs:27:24
+error: invalid delimiter
+  --> $DIR/args.rs:27:23
    |
-27 |     #[auto_enum(never, never, Iterator)] //~ ERROR multiple `never` option
-   |                        ^^^^^
+27 |     #[auto_enum(marker{f}, Iterator)] //~ ERROR invalid delimiter
+   |                       ^^^
 
 error: invalid delimiter
   --> $DIR/args.rs:35:23
    |
-35 |     #[auto_enum(marker{f}, Iterator)] //~ ERROR invalid delimiter
-   |                       ^^^
-
-error: invalid delimiter
-  --> $DIR/args.rs:43:23
-   |
-43 |     #[auto_enum(marker[f], Iterator)] //~ ERROR invalid delimiter
+35 |     #[auto_enum(marker[f], Iterator)] //~ ERROR invalid delimiter
    |                       ^^^
 
 error: multiple `marker` option
-  --> $DIR/args.rs:51:35
+  --> $DIR/args.rs:43:35
    |
-51 |     #[auto_enum(marker(f), marker(g), Iterator)] //~ ERROR multiple `marker` option
+43 |     #[auto_enum(marker(f), marker(g), Iterator)] //~ ERROR multiple `marker` option
    |                                   ^
 
 error: empty `marker` option
-  --> $DIR/args.rs:59:23
+  --> $DIR/args.rs:51:23
    |
-59 |     #[auto_enum(marker(), Iterator)] //~ ERROR empty `marker` option
+51 |     #[auto_enum(marker(), Iterator)] //~ ERROR empty `marker` option
    |                       ^^
 
 error: multiple identifier in `marker` option
-  --> $DIR/args.rs:67:27
+  --> $DIR/args.rs:59:27
    |
-67 |     #[auto_enum(marker(f, g), Iterator)] //~ ERROR multiple identifier in `marker` option
+59 |     #[auto_enum(marker(f, g), Iterator)] //~ ERROR multiple identifier in `marker` option
    |                           ^
 
 error: multiple identifier in `marker` option
-  --> $DIR/args.rs:75:26
+  --> $DIR/args.rs:67:26
    |
-75 |     #[auto_enum(marker(f t), Iterator)] //~ ERROR multiple identifier in `marker` option
+67 |     #[auto_enum(marker(f t), Iterator)] //~ ERROR multiple identifier in `marker` option
    |                          ^
 
 error: multiple `marker` option
-  --> $DIR/args.rs:83:34
+  --> $DIR/args.rs:75:34
    |
-83 |     #[auto_enum(marker=f, marker=g, Iterator)] //~ ERROR multiple `marker` option
+75 |     #[auto_enum(marker=f, marker=g, Iterator)] //~ ERROR multiple `marker` option
    |                                  ^
 
 error: expected an identifier, found `,`
-  --> $DIR/args.rs:91:24
+  --> $DIR/args.rs:83:24
    |
-91 |     #[auto_enum(marker=, Iterator)] //~ ERROR empty `marker` option
+83 |     #[auto_enum(marker=, Iterator)] //~ ERROR empty `marker` option
    |                        ^
 
 error: expected `,`, found `t`
-  --> $DIR/args.rs:99:26
+  --> $DIR/args.rs:91:26
    |
-99 |     #[auto_enum(marker=f t, Iterator)] //~ ERROR expected `,`, found `t`
+91 |     #[auto_enum(marker=f t, Iterator)] //~ ERROR expected `,`, found `t`
    |                          ^
 
-error: aborting due to 12 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
This removes [`never` option in argument position](https://github.com/taiki-e/auto_enums/blob/96e01340db16dffd5df472f80f830749ce1bc92c/src/lib.rs#L472-L492).

It is easier and more flexible to define your own enum using [`#[enum_derive]` attribute](https://docs.rs/auto_enums/0.5.10/auto_enums/#enum_derive).
```rust
#[enum_derive(Iterator)]
enum Either<A, B> {
    A(A),
    B(B),
}

fn foo(x: i32) -> impl Iterator<Item = i32> {
    match x {
        0 => loop {
             return Either::A(1..10);
        },
        1 => loop {
            panic!()
        },
        _ => loop {
            return Either::B(vec![5, 10].into_iter());
        },
    }
}
```