### PR TITLE
core: Remove `marker(name)` option in favor of `marker = name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+* [Removed `marker(name)` option in favor of `marker = name`.][55]
+
 * [Removed `"proc_macro"` crate feature.][54]
 
 [54]: https://github.com/taiki-e/auto_enums/pull/54
+[55]: https://github.com/taiki-e/auto_enums/pull/55
 
 # 0.6.0-alpha.1 - 2019-08-24
 

--- a/core/src/auto_enum/context.rs
+++ b/core/src/auto_enum/context.rs
@@ -11,7 +11,7 @@ use std::{
 use proc_macro2::TokenStream;
 use quote::format_ident;
 use syn::{
-    parse::{Nothing, Parse, ParseStream},
+    parse::{Parse, ParseStream},
     *,
 };
 
@@ -296,35 +296,18 @@ impl Parse for Args {
         let mut marker = None;
 
         while !input.is_empty() {
-            if input.peek(kw::marker) {
-                if input.peek2(Token![=]) {
-                    let _: kw::marker = input.parse()?;
-                    let _: Token![=] = input.parse()?;
-                    let i: Ident = input.parse()?;
-                    if marker.is_some() {
-                        return Err(error!(i, "duplicate `marker` argument"));
-                    } else {
-                        marker = Some(i);
-                        if !input.is_empty() {
-                            let _: token::Comma = input.parse()?;
-                        }
-                        continue;
+            if input.peek(kw::marker) && input.peek2(Token![=]) {
+                let _: kw::marker = input.parse()?;
+                let _: Token![=] = input.parse()?;
+                let i: Ident = input.parse()?;
+                if marker.is_some() {
+                    return Err(error!(i, "duplicate `marker` argument"));
+                } else {
+                    marker = Some(i);
+                    if !input.is_empty() {
+                        let _: token::Comma = input.parse()?;
                     }
-                } else if input.peek2(token::Paren) {
-                    let _: kw::marker = input.parse()?;
-                    let content;
-                    let _ = syn::parenthesized!(content in input);
-                    let i: Ident = content.parse()?;
-                    let _: Nothing = content.parse()?;
-                    if marker.is_some() {
-                        return Err(error!(i, "duplicate `marker` argument"));
-                    } else {
-                        marker = Some(i);
-                        if !input.is_empty() {
-                            let _: token::Comma = input.parse()?;
-                        }
-                        continue;
-                    }
+                    continue;
                 }
             }
 

--- a/tests/auto_enum.rs
+++ b/tests/auto_enum.rs
@@ -469,7 +469,7 @@ mod stable {
         }
         assert_eq!(marker3(10, 10).sum::<i32>(), 63);
 
-        #[auto_enum(marker(marker_a), Iterator)]
+        #[auto_enum(marker = marker_a, Iterator)]
         fn marker4(x: i32, y: i32) -> impl Iterator<Item = i32> {
             let iter;
             #[auto_enum(Iterator)]
@@ -489,7 +489,7 @@ mod stable {
         #[auto_enum(Iterator)]
         fn marker5(x: i32, y: i32) -> impl Iterator<Item = i32> {
             let iter;
-            #[auto_enum(marker(marker_a), Iterator)]
+            #[auto_enum(marker = marker_a, Iterator)]
             match x {
                 0 => iter = marker_a!(2..8),
                 _ if y < 0 => return y..=0,

--- a/tests/ui/auto_enum/args.rs
+++ b/tests/ui/auto_enum/args.rs
@@ -40,32 +40,8 @@ mod marker {
         }
     }
 
-    #[auto_enum(marker(f), marker(g), Iterator)] //~ ERROR duplicate `marker` argument
-    fn multiple_marker(x: usize) -> impl Iterator<Item = i32> {
-        match x {
-            0 => 1..=8,
-            _ => 0..2,
-        }
-    }
-
-    #[auto_enum(marker(), Iterator)] //~ ERROR unexpected end of input, expected identifier
-    fn empty_marker(x: usize) -> impl Iterator<Item = i32> {
-        match x {
-            0 => 1..=8,
-            _ => 0..2,
-        }
-    }
-
-    #[auto_enum(marker(f, g), Iterator)] //~ ERROR unexpected token
-    fn marker_multiple_ident_1(x: usize) -> impl Iterator<Item = i32> {
-        match x {
-            0 => 1..=8,
-            _ => 0..2,
-        }
-    }
-
-    #[auto_enum(marker(f t), Iterator)] //~ ERROR unexpected token
-    fn marker_multiple_ident_2(x: usize) -> impl Iterator<Item = i32> {
+    #[auto_enum(marker(f), Iterator)] //~ ERROR expected `,`
+    fn marker_removed_delimiter(x: usize) -> impl Iterator<Item = i32> {
         match x {
             0 => 1..=8,
             _ => 0..2,
@@ -73,7 +49,7 @@ mod marker {
     }
 
     #[auto_enum(marker = f, marker = g, Iterator)] //~ ERROR duplicate `marker` argument
-    fn multiple_marker_eq(x: usize) -> impl Iterator<Item = i32> {
+    fn multiple_marker(x: usize) -> impl Iterator<Item = i32> {
         match x {
             0 => 1..=8,
             _ => 0..2,
@@ -81,7 +57,7 @@ mod marker {
     }
 
     #[auto_enum(marker =, Iterator)] //~ ERROR expected identifier
-    fn empty_marker_eq(x: usize) -> impl Iterator<Item = i32> {
+    fn empty_marker(x: usize) -> impl Iterator<Item = i32> {
         match x {
             0 => 1..=8,
             _ => 0..2,
@@ -89,7 +65,7 @@ mod marker {
     }
 
     #[auto_enum(marker = f t, Iterator)] //~ ERROR expected `,`
-    fn marker_eq_multiple_ident(x: usize) -> impl Iterator<Item = i32> {
+    fn marker_multiple_ident(x: usize) -> impl Iterator<Item = i32> {
         match x {
             0 => 1..=8,
             _ => 0..2,

--- a/tests/ui/auto_enum/args.stderr
+++ b/tests/ui/auto_enum/args.stderr
@@ -22,47 +22,29 @@ error: expected `,`
 35 |     #[auto_enum(marker[f], Iterator)] //~ ERROR expected `,`
    |                       ^^^
 
-error: duplicate `marker` argument
-  --> $DIR/args.rs:43:35
+error: expected `,`
+  --> $DIR/args.rs:43:23
    |
-43 |     #[auto_enum(marker(f), marker(g), Iterator)] //~ ERROR duplicate `marker` argument
-   |                                   ^
-
-error: unexpected end of input, expected identifier
-  --> $DIR/args.rs:51:24
-   |
-51 |     #[auto_enum(marker(), Iterator)] //~ ERROR unexpected end of input, expected identifier
-   |                        ^
-
-error: unexpected token
-  --> $DIR/args.rs:59:25
-   |
-59 |     #[auto_enum(marker(f, g), Iterator)] //~ ERROR unexpected token
-   |                         ^
-
-error: unexpected token
-  --> $DIR/args.rs:67:26
-   |
-67 |     #[auto_enum(marker(f t), Iterator)] //~ ERROR unexpected token
-   |                          ^
+43 |     #[auto_enum(marker(f), Iterator)] //~ ERROR expected `,`
+   |                       ^^^
 
 error: duplicate `marker` argument
-  --> $DIR/args.rs:75:38
+  --> $DIR/args.rs:51:38
    |
-75 |     #[auto_enum(marker = f, marker = g, Iterator)] //~ ERROR duplicate `marker` argument
+51 |     #[auto_enum(marker = f, marker = g, Iterator)] //~ ERROR duplicate `marker` argument
    |                                      ^
 
 error: expected identifier
-  --> $DIR/args.rs:83:25
+  --> $DIR/args.rs:59:25
    |
-83 |     #[auto_enum(marker =, Iterator)] //~ ERROR expected identifier
+59 |     #[auto_enum(marker =, Iterator)] //~ ERROR expected identifier
    |                         ^
 
 error: expected `,`
-  --> $DIR/args.rs:91:28
+  --> $DIR/args.rs:67:28
    |
-91 |     #[auto_enum(marker = f t, Iterator)] //~ ERROR expected `,`
+67 |     #[auto_enum(marker = f t, Iterator)] //~ ERROR expected `,`
    |                            ^
 
-error: aborting due to 11 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
I think `marker = name` is clearer.