### PR TITLE
core: Remove usage of mutable global state

### DIFF
--- a/tests/auto_enum.rs
+++ b/tests/auto_enum.rs
@@ -759,6 +759,18 @@ mod nightly {
             (if option { |x| x + 1 } else { |y| y - 1 }): _
         }
         assert_eq!(fn_traits2(true)(1), 2);
+
+        #[auto_enum(Iterator, Clone)]
+        let _y = match 0 {
+            0 => 2..8,
+            _ => 2..=10,
+        };
+
+        #[auto_enum(Iterator, Clone)]
+        let _x = match 0 {
+            0 => 2..8,
+            _ => 2..=10,
+        };
     }
 
     #[test]


### PR DESCRIPTION
It may be a warning in the future. So, use the hash value of the input AST instead of PRNG.

See https://github.com/rust-lang/rust/pull/64398#issuecomment-533186558 and https://github.com/rust-lang/rust/pull/63831.