### PR TITLE
Remove some unstable features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* [Removed unstable `"exact_size_is_empty"`, `"read_initializer"`, and `"try_trait"` crate features.][69]
+
+[69]: https://github.com/taiki-e/auto_enums/pull/69
+
 # 0.6.4 - 2019-09-28
 
 * Updated to support `futures-preview` 0.3.0-alpha.19.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,7 @@ serde = ["auto_enums_derive/serde"]
 # Unstable features
 # These features are outside of the normal semver guarantees and require the
 # `unstable` feature as an explicit opt-in to unstable API.
-unstable = ["auto_enums_core/unstable", "auto_enums_derive/unstable"]
-
-# Make `?` operator support more flexible, and to make iterator implementation more effective.
-try_trait = ["auto_enums_core/try_trait", "auto_enums_derive/try_trait"]
+unstable = ["auto_enums_derive/unstable"]
 
 # external libraries
 
@@ -82,8 +79,3 @@ generator_trait = ["auto_enums_derive/generator_trait"]
 fn_traits = ["auto_enums_derive/fn_traits"]
 # Enable to use `[std|core]::iter::TrustedLen` trait.
 trusted_len = ["auto_enums_derive/trusted_len"]
-
-# Implements `ExactSizeIterator::is_empty`.
-exact_size_is_empty = ["auto_enums_derive/exact_size_is_empty"]
-# Implements `std::io::Read::read_initializer`.
-read_initializer = ["auto_enums_derive/read_initializer"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,12 +26,3 @@ default = []
 
 # Analyze return type of function and `let` binding.
 type_analysis = ["syn/extra-traits"]
-
-# ==============================================================================
-# Unstable features
-# These features are outside of the normal semver guarantees and require the
-# `unstable` feature as an explicit opt-in to unstable API.
-unstable = []
-
-# Make `?` operator support more flexible.
-try_trait = []

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,11 +11,6 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::use_self)]
 
-#[cfg(all(feature = "try_trait", not(feature = "unstable")))]
-compile_error!(
-    "The `try_trait` feature requires the `unstable` feature as an explicit opt-in to unstable features"
-);
-
 extern crate proc_macro;
 
 #[macro_use]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -75,11 +75,3 @@ generator_trait = []
 fn_traits = []
 # Enable to use `[std|core]::iter::TrustedLen` trait.
 trusted_len = []
-
-# Implements `ExactSizeIterator::is_empty`.
-exact_size_is_empty = []
-# Implements `std::io::Read::read_initializer`.
-read_initializer = []
-
-# Make iterator implementation more effective.
-try_trait = []

--- a/derive/src/derive/core/iter/double_ended_iterator.rs
+++ b/derive/src/derive/core/iter/double_ended_iterator.rs
@@ -3,16 +3,9 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["DoubleEndedIterator"];
 
 pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
-    #[cfg(feature = "try_trait")]
-    let try_trait = quote! {
-        #[inline]
-        fn try_rfold<__U, __F, __R>(&mut self, init: __U, f: __F) -> __R
-        where
-            __F: ::core::ops::FnMut(__U, Self::Item) -> __R,
-            __R: ::core::ops::Try<Ok = __U>;
-    };
+    // TODO: When `try_trait` stabilized, add `try_rfold` and remove `rfold` and `rfind` conditionally.
+
     // It is equally efficient if `try_rfold` can be used.
-    #[cfg(not(feature = "try_trait"))]
     let try_trait = quote! {
         #[inline]
         fn rfold<__U, __F>(self, accum: __U, f: __F) -> __U

--- a/derive/src/derive/core/iter/exact_size_iterator.rs
+++ b/derive/src/derive/core/iter/exact_size_iterator.rs
@@ -3,13 +3,7 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["ExactSizeIterator"];
 
 pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
-    #[cfg(not(feature = "exact_size_is_empty"))]
-    let is_empty = quote!();
-    #[cfg(feature = "exact_size_is_empty")]
-    let is_empty = quote! {
-        #[inline]
-        fn is_empty(&self) -> bool;
-    };
+    // TODO: When `exact_size_is_empty` stabilized, add `is_empty` conditionally.
 
     derive_trait!(
         data,
@@ -19,7 +13,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
             trait ExactSizeIterator: ::core::iter::Iterator {
                 #[inline]
                 fn len(&self) -> usize;
-                #is_empty
             }
         }?,
     )

--- a/derive/src/derive/core/iter/iterator.rs
+++ b/derive/src/derive/core/iter/iterator.rs
@@ -3,16 +3,9 @@ use crate::utils::*;
 pub(crate) const NAME: &[&str] = &["Iterator"];
 
 pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
-    #[cfg(feature = "try_trait")]
-    let try_trait = quote! {
-        #[inline]
-        fn try_fold<__U, __F, __R>(&mut self, init: __U, f: __F) -> __R
-        where
-            __F: ::core::ops::FnMut(__U, Self::Item) -> __R,
-            __R: ::core::ops::Try<Ok = __U>;
-    };
+    // TODO: When `try_trait` stabilized, add `try_fold` and remove `fold`, `find` etc. conditionally.
+
     // It is equally efficient if `try_fold` can be used.
-    #[cfg(not(feature = "try_trait"))]
     let try_trait = quote! {
         #[inline]
         fn fold<__U, __F>(self, init: __U, f: __F) -> __U

--- a/derive/src/derive/std/io/read.rs
+++ b/derive/src/derive/std/io/read.rs
@@ -11,13 +11,7 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         fn read_vectored(&mut self, bufs: &mut [::std::io::IoSliceMut<'_>]) -> ::std::io::Result<usize>;
     };
 
-    #[cfg(not(feature = "read_initializer"))]
-    let initializer = quote!();
-    #[cfg(feature = "read_initializer")]
-    let initializer = quote! {
-        #[inline]
-        unsafe fn initializer(&self) -> ::std::io::Initializer;
-    };
+    // TODO: When `read_initializer` stabilized, add `initializer` conditionally.
 
     derive_trait!(
         data,
@@ -33,7 +27,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
                 #[inline]
                 fn read_exact(&mut self, buf: &mut [u8]) -> ::std::io::Result<()>;
                 #vectored
-                #initializer
             }
         }?,
     )

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -9,11 +9,6 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::use_self)]
 
-#[cfg(all(feature = "try_trait", not(feature = "unstable")))]
-compile_error!(
-    "The `try_trait` feature requires the `unstable` feature as an explicit opt-in to unstable features"
-);
-
 #[cfg(all(feature = "futures", not(feature = "unstable")))]
 compile_error!(
     "The `futures` feature requires the `unstable` feature as an explicit opt-in to unstable features"
@@ -32,16 +27,6 @@ compile_error!(
 #[cfg(all(feature = "trusted_len", not(feature = "unstable")))]
 compile_error!(
     "The `trusted_len` feature requires the `unstable` feature as an explicit opt-in to unstable features"
-);
-
-#[cfg(all(feature = "exact_size_is_empty", not(feature = "unstable")))]
-compile_error!(
-    "The `exact_size_is_empty` feature requires the `unstable` feature as an explicit opt-in to unstable features"
-);
-
-#[cfg(all(feature = "read_initializer", not(feature = "unstable")))]
-compile_error!(
-    "The `read_initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features"
 );
 
 extern crate proc_macro;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 //! specified traits.
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! use auto_enums::auto_enum;
 //!
 //! #[auto_enum(Iterator)]
@@ -42,7 +41,6 @@
 //! Code like this will be generated:
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! fn foo(x: i32) -> impl Iterator<Item = i32> {
 //!     #[::auto_enums::enum_derive(Iterator)]
 //!     enum __Enum1<__T1, __T2> {
@@ -64,7 +62,6 @@
 //! <summary>Code like this will be generated:</summary>
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! fn foo(x: i32) -> impl Iterator<Item = i32> {
 //!     enum __Enum1<__T1, __T2> {
 //!         __T1(__T1),
@@ -108,7 +105,6 @@
 //! attribute.
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! # use auto_enums::auto_enum;
 //! #[auto_enum(Iterator)]
 //! fn foo(x: i32) -> impl Iterator<Item = i32> {
@@ -136,7 +132,6 @@
 //! * functions
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   #[auto_enum(Iterator)]
 //!   fn func(x: i32) -> impl Iterator<Item=i32> {
@@ -152,7 +147,6 @@
 //! * expressions
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   #[auto_enum] // Nightly does not need an empty attribute to the function.
 //!   fn expr(x: i32) -> impl Iterator<Item=i32> {
@@ -168,7 +162,6 @@
 //! * let binding
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   #[auto_enum] // Nightly does not need an empty attribute to the function.
 //!   fn let_binding(x: i32) -> impl Iterator<Item=i32> {
@@ -189,7 +182,6 @@
 //!   Wrap each branch with a variant.
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   // if
 //!   #[auto_enum(Iterator)]
@@ -220,7 +212,6 @@
 //!   also supported.
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   #[auto_enum(Iterator)]
 //!   fn expr_loop(mut x: i32) -> impl Iterator<Item = i32> {
@@ -243,7 +234,6 @@
 //!   This analysis is valid only when the return type is `impl Trait`.
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   // return (in functions)
 //!   #[auto_enum(Iterator)]
@@ -271,7 +261,6 @@
 //!     * `?` operator not used in the scope.
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   // return (in closures)
 //!   #[auto_enum] // Nightly does not need an empty attribute to the function.
@@ -300,7 +289,6 @@
 //!   This analysis is valid only when the return type is `Result<T, impl Trait>`.
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   use std::fmt::{Debug, Display};
 //!
@@ -335,27 +323,6 @@
 //!   # }
 //!   ```
 //!
-//!   When "try_trait" crate feature is enabled, `?` operator is expanded as
-//!   follows (note that this uses [an unstable feature](https://github.com/rust-lang/rust/issues/42327)):
-//!
-//!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
-//!   # #[cfg(feature = "try_trait")]
-//!   # use std::ops::Try;
-//!   # #[cfg(feature = "try_trait")]
-//!   # pub enum Enum<A> { Veriant(A) }
-//!   # #[cfg(feature = "try_trait")]
-//!   # pub fn a<T, E>(expr: Result<T, E>) -> Result<T, Enum<E>> {
-//!   # Ok(
-//!   match Try::into_result(expr) {
-//!       Ok(val) => val,
-//!       Err(err) => return Try::from_error(Enum::Veriant(err)),
-//!   }
-//!   # )
-//!   # }
-//!   # fn main() {}
-//!   ```
-//!
 //! * `?` operator (in closures)
 //!
 //!   `#[auto_enum]` can parse the `?` operator in the scope.
@@ -364,7 +331,6 @@
 //!   (or the let binding of the closure).
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   use std::fmt::{Debug, Display};
 //!
@@ -401,7 +367,6 @@
 //!   * type ascriptions
 //!
 //!   ```rust
-//!   # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!   # use auto_enums::auto_enum;
 //!   // block
 //!   #[auto_enum] // Nightly does not need an empty attribute to the function.
@@ -450,7 +415,6 @@
 //! * An item definition.
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! # use auto_enums::auto_enum;
 //! #[auto_enum(Iterator)]
 //! fn foo(x: i32) -> impl Iterator<Item = i32> {
@@ -466,7 +430,6 @@
 //! You can also skip that branch explicitly by `#[never]` attribute.
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! # use auto_enums::auto_enum;
 //! #[auto_enum(Iterator)]
 //! fn foo(x: i32) -> impl Iterator<Item = i32> {
@@ -489,7 +452,6 @@
 //! can be used for unsupported expressions and statements.
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! # use auto_enums::auto_enum;
 //! #[auto_enum(Iterator)]
 //! fn foo(x: i32) -> impl Iterator<Item = i32> {
@@ -505,7 +467,6 @@
 //! `marker` option.
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! # use auto_enums::auto_enum;
 //! #[auto_enum(marker = bar, Iterator)]
 //! fn foo(x: i32) -> impl Iterator<Item = i32> {
@@ -529,7 +490,6 @@
 //! ```
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! # #![feature(proc_macro_hygiene, stmt_expr_attributes)]
 //! # use auto_enums::auto_enum;
 //! fn foo(x: i32) -> i32 {
@@ -574,7 +534,6 @@
 //! Basic usage of `#[enum_derive]`
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //! use auto_enums::enum_derive;
 //!
 //! // `#[enum_derive]` implements `Iterator`, and `#[derive]` implements `Clone`.
@@ -590,8 +549,6 @@
 //! specified.
 //!
 //! ```rust
-//! # #![cfg_attr(feature = "try_trait", feature(try_trait))]
-//! # #![cfg_attr(feature = "exact_size_is_empty", feature(exact_size_is_empty))]
 //! use auto_enums::enum_derive;
 //!
 //! // `#[enum_derive]` implements `Iterator` and `ExactSizeIterator`.
@@ -760,7 +717,6 @@
 //!     Examples:
 //!
 //!     ```rust
-//!     # #![cfg_attr(feature = "try_trait", feature(try_trait))]
 //!     # #[cfg(feature = "type_analysis")]
 //!     # use auto_enums::auto_enum;
 //!     # #[cfg(feature = "type_analysis")]
@@ -782,11 +738,6 @@
 //! * `transpose_methods`
 //!   * Disabled by default.
 //!   * Enable to use `transpose*` methods.
-//!
-//! * `try_trait` *(requires `"unstable"` crate feature)*
-//!   * Disabled by default.
-//!   * Make `?` operator support more flexible, and to make iterator implementation more effective.
-//!   * This requires Rust Nightly and you need to enable the unstable [`try_trait`](https://github.com/rust-lang/rust/issues/42327) feature gate.
 //!
 //! ### Using external libraries (disabled by default)
 //!
@@ -810,12 +761,6 @@
 //!
 //! * [`trusted_len`](https://github.com/rust-lang/rust/issues/37572) - Enable to use `[std|core]::iter::TrustedLen` trait.
 //!
-//! * [`exact_size_is_empty`](https://github.com/rust-lang/rust/issues/35428) - Implements `ExactSizeIterator::is_empty`.
-//!
-//! * [`read_initializer`](https://github.com/rust-lang/rust/issues/42788) - Implements `std::io::Read::read_initializer`.
-//!
-//! * [`try_trait`](https://github.com/rust-lang/rust/issues/42327) - Make iterator implementation more effective.
-//!
 //! ## Known limitations
 //!
 //! * There needs to explicitly specify the trait to be implemented (`type_analysis` crate feature reduces this limitation).
@@ -833,11 +778,6 @@
 #![warn(rust_2018_idioms, single_use_lifetimes, unreachable_pub)]
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::use_self)]
-
-#[cfg(all(feature = "try_trait", not(feature = "unstable")))]
-compile_error!(
-    "The `try_trait` feature requires the `unstable` feature as an explicit opt-in to unstable features"
-);
 
 #[cfg(all(feature = "futures", not(feature = "unstable")))]
 compile_error!(
@@ -857,16 +797,6 @@ compile_error!(
 #[cfg(all(feature = "trusted_len", not(feature = "unstable")))]
 compile_error!(
     "The `trusted_len` feature requires the `unstable` feature as an explicit opt-in to unstable features"
-);
-
-#[cfg(all(feature = "exact_size_is_empty", not(feature = "unstable")))]
-compile_error!(
-    "The `exact_size_is_empty` feature requires the `unstable` feature as an explicit opt-in to unstable features"
-);
-
-#[cfg(all(feature = "read_initializer", not(feature = "unstable")))]
-compile_error!(
-    "The `read_initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features"
 );
 
 #[doc(hidden)]

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -18,7 +18,4 @@ serde = "1.0"
 unstable = [
     "auto_enums/unstable",
     "auto_enums/futures",
-    "auto_enums/try_trait",
-    "auto_enums/exact_size_is_empty",
-    "auto_enums/read_initializer",
 ]

--- a/test_suite/benches/vs_boxed.rs
+++ b/test_suite/benches/vs_boxed.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 #![feature(box_syntax)]
-#![cfg_attr(feature = "unstable", feature(try_trait))]
 #![warn(unsafe_code)]
 #![warn(rust_2018_idioms)]
 

--- a/tests/auto_enum.rs
+++ b/tests/auto_enum.rs
@@ -1,13 +1,10 @@
 #![cfg_attr(
-    any(feature = "try_trait", feature = "fn_traits"),
+    feature = "fn_traits",
     feature(proc_macro_hygiene, stmt_expr_attributes, type_ascription)
 )]
-#![cfg_attr(feature = "try_trait", feature(try_trait))]
 #![cfg_attr(feature = "generator_trait", feature(generator_trait))]
 #![cfg_attr(feature = "fn_traits", feature(fn_traits, unboxed_closures))]
 #![cfg_attr(feature = "trusted_len", feature(trusted_len))]
-#![cfg_attr(feature = "exact_size_is_empty", feature(exact_size_is_empty))]
-#![cfg_attr(feature = "read_initializer", feature(read_initializer))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms)]
 
@@ -597,7 +594,7 @@ mod stable {
 }
 
 // nightly
-#[cfg(all(feature = "try_trait", feature = "fn_traits"))]
+#[cfg(feature = "fn_traits")]
 mod nightly {
     use auto_enums::auto_enum;
 
@@ -820,24 +817,5 @@ mod nightly {
         for (i, x) in ANS.iter().enumerate() {
             assert_eq!(marker2(i).clone().sum::<i32>(), *x - 1);
         }
-    }
-
-    #[test]
-    fn try_trait() {
-        #[auto_enum(Debug)]
-        fn try_operator(x: i32) -> Result<impl Iterator<Item = i32>, impl core::fmt::Debug> {
-            if x < 0 {
-                Err(1i32)?;
-            }
-
-            let iter = match x {
-                0 => Err(())?,
-                1 => None?,
-                _ => 2..=10,
-            };
-
-            Ok(iter)
-        }
-        assert_eq!(try_operator(10).unwrap().sum::<i32>(), 54);
     }
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,9 +1,4 @@
-#![cfg(all(
-    feature = "std",
-    feature = "type_analysis",
-    feature = "transpose_methods",
-    feature = "try_trait",
-))]
+#![cfg(all(feature = "std", feature = "type_analysis", feature = "transpose_methods",))]
 #![warn(rust_2018_idioms)]
 
 #[test]

--- a/tests/enum_derive.rs
+++ b/tests/enum_derive.rs
@@ -1,9 +1,6 @@
-#![cfg_attr(feature = "try_trait", feature(try_trait))]
 #![cfg_attr(feature = "generator_trait", feature(generator_trait))]
 #![cfg_attr(feature = "fn_traits", feature(fn_traits, unboxed_closures))]
 #![cfg_attr(feature = "trusted_len", feature(trusted_len))]
-#![cfg_attr(feature = "exact_size_is_empty", feature(exact_size_is_empty))]
-#![cfg_attr(feature = "read_initializer", feature(read_initializer))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unsafe_code)]
 #![warn(rust_2018_idioms)]
@@ -136,36 +133,6 @@ fn fn_traits() {
 #[test]
 fn trusted_len() {
     #[enum_derive(TrustedLen)]
-    enum Enum1<A, B> {
-        A(A),
-        B(B),
-    }
-}
-
-#[cfg(feature = "try_trait")]
-#[test]
-fn try_trait() {
-    #[enum_derive(Iterator)]
-    enum Enum1<A, B> {
-        A(A),
-        B(B),
-    }
-}
-
-#[cfg(feature = "exact_size_is_empty")]
-#[test]
-fn exact_size_is_empty() {
-    #[enum_derive(ExactSizeIterator)]
-    enum Enum1<A, B> {
-        A(A),
-        B(B),
-    }
-}
-
-#[cfg(feature = "read_initializer")]
-#[test]
-fn read_initializer() {
-    #[enum_derive(Read)]
     enum Enum1<A, B> {
         A(A),
         B(B),

--- a/tests/ui/auto_enum/args.rs
+++ b/tests/ui/auto_enum/args.rs
@@ -1,7 +1,5 @@
 // compile-fail
 
-#![feature(try_trait)]
-
 use auto_enums::auto_enum;
 
 #[auto_enum(Iterator;)] //~ ERROR expected `,`

--- a/tests/ui/auto_enum/args.stderr
+++ b/tests/ui/auto_enum/args.stderr
@@ -1,47 +1,47 @@
 error: expected `,`
- --> $DIR/args.rs:7:21
+ --> $DIR/args.rs:5:21
   |
-7 | #[auto_enum(Iterator;)] //~ ERROR expected `,`
+5 | #[auto_enum(Iterator;)] //~ ERROR expected `,`
   |                     ^
 
 error: expected identifier
-  --> $DIR/args.rs:15:22
+  --> $DIR/args.rs:13:22
    |
-15 | #[auto_enum(Iterator,;)] //~ ERROR expected identifier
+13 | #[auto_enum(Iterator,;)] //~ ERROR expected identifier
    |                      ^
 
 error: expected `,`
-  --> $DIR/args.rs:26:23
+  --> $DIR/args.rs:24:23
    |
-26 |     #[auto_enum(marker{f}, Iterator)] //~ ERROR expected `,`
+24 |     #[auto_enum(marker{f}, Iterator)] //~ ERROR expected `,`
    |                       ^^^
 
 error: expected `,`
-  --> $DIR/args.rs:34:23
+  --> $DIR/args.rs:32:23
    |
-34 |     #[auto_enum(marker[f], Iterator)] //~ ERROR expected `,`
+32 |     #[auto_enum(marker[f], Iterator)] //~ ERROR expected `,`
    |                       ^^^
 
 error: expected `,`
-  --> $DIR/args.rs:42:23
+  --> $DIR/args.rs:40:23
    |
-42 |     #[auto_enum(marker(f), Iterator)] //~ ERROR expected `,`
+40 |     #[auto_enum(marker(f), Iterator)] //~ ERROR expected `,`
    |                       ^^^
 
 error: duplicate `marker` argument
-  --> $DIR/args.rs:50:38
+  --> $DIR/args.rs:48:38
    |
-50 |     #[auto_enum(marker = f, marker = g, Iterator)] //~ ERROR duplicate `marker` argument
+48 |     #[auto_enum(marker = f, marker = g, Iterator)] //~ ERROR duplicate `marker` argument
    |                                      ^
 
 error: expected identifier
-  --> $DIR/args.rs:58:25
+  --> $DIR/args.rs:56:25
    |
-58 |     #[auto_enum(marker =, Iterator)] //~ ERROR expected identifier
+56 |     #[auto_enum(marker =, Iterator)] //~ ERROR expected identifier
    |                         ^
 
 error: expected `,`
-  --> $DIR/args.rs:66:28
+  --> $DIR/args.rs:64:28
    |
-66 |     #[auto_enum(marker = f t, Iterator)] //~ ERROR expected `,`
+64 |     #[auto_enum(marker = f t, Iterator)] //~ ERROR expected `,`
    |                            ^

--- a/tests/ui/auto_enum/attribute.rs
+++ b/tests/ui/auto_enum/attribute.rs
@@ -1,7 +1,5 @@
 // compile-fail
 
-#![feature(try_trait)]
-
 use auto_enums::auto_enum;
 
 #[auto_enum(Iterator)]

--- a/tests/ui/auto_enum/attribute.stderr
+++ b/tests/ui/auto_enum/attribute.stderr
@@ -1,17 +1,17 @@
 error: unexpected token
-  --> $DIR/attribute.rs:11:16
-   |
-11 |         #[never(foo)] //~ ERROR unexpected token
-   |                ^
+ --> $DIR/attribute.rs:9:16
+  |
+9 |         #[never(foo)] //~ ERROR unexpected token
+  |                ^
 
 error: unexpected token
-  --> $DIR/attribute.rs:21:17
+  --> $DIR/attribute.rs:19:17
    |
-21 |         #[nested(foo)] //~ ERROR unexpected token
+19 |         #[nested(foo)] //~ ERROR unexpected token
    |                 ^
 
 error: #[rec] has been removed and replaced with #[nested]
-  --> $DIR/attribute.rs:31:9
+  --> $DIR/attribute.rs:29:9
    |
-31 |         #[rec] //~ ERROR #[rec] has been removed and replaced with #[nested]
+29 |         #[rec] //~ ERROR #[rec] has been removed and replaced with #[nested]
    |         ^^^^^^

--- a/tests/ui/auto_enum/compile-fail.rs
+++ b/tests/ui/auto_enum/compile-fail.rs
@@ -1,7 +1,5 @@
 // compile-fail
 
-#![feature(try_trait)]
-
 use auto_enums::auto_enum;
 
 #[auto_enum(Iterator)]

--- a/tests/ui/auto_enum/compile-fail.stderr
+++ b/tests/ui/auto_enum/compile-fail.stderr
@@ -1,42 +1,40 @@
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `..`
-  --> $DIR/compile-fail.rs:10:26
-   |
-10 |         0 => marker!(1..8..), //~ ERROR expected one of `)`, `,`, `.`, `?`, or an operator, found `..`
-   |                          ^^ expected one of `)`, `,`, `.`, `?`, or an operator here
+ --> $DIR/compile-fail.rs:8:26
+  |
+8 |         0 => marker!(1..8..), //~ ERROR expected one of `)`, `,`, `.`, `?`, or an operator, found `..`
+  |                          ^^ expected one of `)`, `,`, `.`, `?`, or an operator here
 
 error: `if` expression missing an else clause
-  --> $DIR/compile-fail.rs:19:12
+  --> $DIR/compile-fail.rs:17:12
    |
-19 |     } else if x > 3 {
+17 |     } else if x > 3 {
    |            ^^
 
 error: `#[auto_enum]` is required two or more branches or marker macros in total, there is only one branch or marker macro in this statement
-  --> $DIR/compile-fail.rs:28:5
+  --> $DIR/compile-fail.rs:26:5
    |
-28 | /     let iter = match x {
-29 | |         //~^ ERROR `#[auto_enum]` is required two or more branches or marker macros in total, there is only one branch or marker macro in this statement
-30 | |         _ if y < 0 => return y..=0,
-31 | |         _ => 2..=10,
-32 | |     };
+26 | /     let iter = match x {
+27 | |         //~^ ERROR `#[auto_enum]` is required two or more branches or marker macros in total, there is only one branch or marker macro in this statement
+28 | |         _ if y < 0 => return y..=0,
+29 | |         _ => 2..=10,
+30 | |     };
    | |______^
 
 error: `#[auto_enum]` is required two or more branches or marker macros in total, there is no branch or marker macro in this statement
-  --> $DIR/compile-fail.rs:43:5
+  --> $DIR/compile-fail.rs:41:5
    |
-43 | /     let iter = match x {
-44 | |         //~^ ERROR `#[auto_enum]` is required two or more branches or marker macros in total, there is no branch or marker macro in this statement
-45 | |         _ if y < 0 => return y..=0,
-46 | |         _ => return 2..=10,
-47 | |     };
+41 | /     let iter = match x {
+42 | |         //~^ ERROR `#[auto_enum]` is required two or more branches or marker macros in total, there is no branch or marker macro in this statement
+43 | |         _ if y < 0 => return y..=0,
+44 | |         _ => return 2..=10,
+45 | |     };
    | |______^
 
 error[E0061]: this function takes 1 parameter but 2 parameters were supplied
- --> $DIR/compile-fail.rs:7:1
+ --> $DIR/compile-fail.rs:5:1
   |
-7 | #[auto_enum(Iterator)]
+5 | #[auto_enum(Iterator)]
   | ^^^^^^^^^^^^^^^^^^^^^^
   | |
   | defined here
   | expected 1 parameter
-
-For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/auto_enum/marker.rs
+++ b/tests/ui/auto_enum/marker.rs
@@ -1,7 +1,5 @@
 // compile-fail
 
-#![feature(try_trait)]
-
 use auto_enums::auto_enum;
 
 #[auto_enum(Iterator, marker = foo)]

--- a/tests/ui/auto_enum/marker.stderr
+++ b/tests/ui/auto_enum/marker.stderr
@@ -1,11 +1,11 @@
 error: A custom marker name is specified that duplicated the name already used in the parent scope
- --> $DIR/marker.rs:9:36
+ --> $DIR/marker.rs:7:36
   |
-9 |     #[auto_enum(Iterator, marker = foo)]
+7 |     #[auto_enum(Iterator, marker = foo)]
   |                                    ^^^
 
 error: cannot find macro `marker` in this scope
-  --> $DIR/marker.rs:29:21
+  --> $DIR/marker.rs:27:21
    |
-29 |         2 => return marker!(1..9), //~ ERROR cannot find macro `marker!` in this scope
+27 |         2 => return marker!(1..9), //~ ERROR cannot find macro `marker!` in this scope
    |                     ^^^^^^

--- a/tests/ui/auto_enum/rejected-by-rustc.rs
+++ b/tests/ui/auto_enum/rejected-by-rustc.rs
@@ -1,7 +1,5 @@
 // compile-fail
 
-#![feature(try_trait)]
-
 use auto_enums::auto_enum;
 
 #[auto_enum(Iterator)]

--- a/tests/ui/auto_enum/rejected-by-rustc.stderr
+++ b/tests/ui/auto_enum/rejected-by-rustc.stderr
@@ -1,18 +1,18 @@
 error: expected `{`, found keyword `return`
-  --> $DIR/rejected-by-rustc.rs:11:12
-   |
-11 |     } else return {
-   |            ^^^^^^ expected `{`
+ --> $DIR/rejected-by-rustc.rs:9:12
+  |
+9 |     } else return {
+  |            ^^^^^^ expected `{`
 help: try placing this code inside a block
-   |
-11 |     } else { return {
-12 |         //~^ ERROR expected `{`, found keyword `return`
-13 |         2..=10
-14 |     } }
-   |
+  |
+9 |     } else { return {
+10|         //~^ ERROR expected `{`, found keyword `return`
+11|         2..=10
+12|     } }
+  |
 
 error: attributes are not yet allowed on `if` expressions
-  --> $DIR/rejected-by-rustc.rs:22:9
+  --> $DIR/rejected-by-rustc.rs:20:9
    |
-22 |         #[nested]
+20 |         #[nested]
    |         ^^^^^^^^^


### PR DESCRIPTION
It shouldn't actually use these features because using both the crate with these features enabled and the crate with no these features enabled at the same time can result in errors.