### PR TITLE
Mark auto_enums_core and auto_enums_derive as internal crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,6 @@ auto_enums_derive = { version = "=0.6.4", path = "derive", default-features = fa
 [dev-dependencies]
 trybuild = "1.0"
 futures-preview = "0.3.0-alpha.19"
-rayon_crate = { version = "1", package = "rayon" }
-serde_crate = { version = "1", package = "serde" }
+rayon_crate = { version = "1.2", package = "rayon" }
+serde_crate = { version = "1.0", package = "serde" }
 rand = "0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/auto_enums_core/"
 keywords = ["enum", "macros", "derive", "attribute"]
 categories = ["rust-patterns"]
 description = """
-This library provides an attribute macro for to allow multiple return types by automatically generated enum.
+An internal crate to support auto_enums - do not use directly
 """
 
 [lib]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,5 @@
+//! An internal crate to support auto_enums - **do not use directly**
+
 #![recursion_limit = "256"]
 #![doc(html_root_url = "https://docs.rs/auto_enums_core/0.6.4")]
 #![doc(test(
@@ -23,5 +25,5 @@ use proc_macro::TokenStream;
 /// An attribute macro for to allow multiple return types by automatically generated enum.
 #[proc_macro_attribute]
 pub fn auto_enum(args: TokenStream, input: TokenStream) -> TokenStream {
-    TokenStream::from(self::auto_enum::attribute(args.into(), input.into()))
+    crate::auto_enum::attribute(args.into(), input.into()).into()
 }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/auto_enums_derive/"
 keywords = ["enum", "macros", "derive", "attribute"]
 categories = ["rust-patterns"]
 description = """
-This library provides an attribute macro like a wrapper of `#[derive]`, implementing the supported traits and passing unsupported traits to `#[derive]`.
+An internal crate to support auto_enums - do not use directly
 """
 
 [lib]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,3 +1,5 @@
+//! An internal crate to support auto_enums - **do not use directly**
+
 #![recursion_limit = "256"]
 #![doc(html_root_url = "https://docs.rs/auto_enums_derive/0.6.4")]
 #![doc(test(
@@ -43,5 +45,5 @@ use proc_macro::TokenStream;
 /// the supported traits and passing unsupported traits to `#[derive]`.
 #[proc_macro_attribute]
 pub fn enum_derive(args: TokenStream, input: TokenStream) -> TokenStream {
-    TokenStream::from(self::enum_derive::attribute(args.into(), input.into()))
+    crate::enum_derive::attribute(args.into(), input.into()).into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -780,7 +780,7 @@ compile_error!(
     "The `trusted_len` feature requires the `unstable` feature as an explicit opt-in to unstable features"
 );
 
-#[doc(hidden)]
+#[doc(inline)]
 pub use auto_enums_core::auto_enum;
-#[doc(hidden)]
+#[doc(inline)]
 pub use auto_enums_derive::enum_derive;


### PR DESCRIPTION
Some previous versions could actually have been used directly,
but that was not intentional and not officially supported.