### PR TITLE
Add unstable flag to extend compiletest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
         if: matrix.rust == 'nightly'
         run: |
           cargo test --all --all-features
+      - name: cargo test --cfg auto_enums_def_site_enum_ident
+        if: matrix.rust == 'nightly'
+        run: |
+          cargo test --all --all-features -- -Zunstable-options --include-ignored
+        env:
+          RUSTFLAGS: -Dwarnings --cfg auto_enums_def_site_enum_ident
       - name: cargo check --benches
         if: matrix.rust == 'nightly'
         run: |

--- a/ci.sh
+++ b/ci.sh
@@ -19,3 +19,6 @@ RUSTFLAGS=-Dwarnings cargo +nightly test --all --all-features
 
 echo "Running 'cargo doc'"
 RUSTDOCFLAGS=-Dwarnings cargo +nightly doc --no-deps --all --all-features
+
+echo "Running 'compiletest'"
+. ./compiletest.sh

--- a/compiletest.sh
+++ b/compiletest.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# A script to run compile tests with the same condition of the checks done by CI.
+#
+# Usage
+#
+# ```sh
+# . ./compiletest.sh
+# ```
+
+TRYBUILD=overwrite RUSTFLAGS='--cfg auto_enums_def_site_enum_ident' cargo +nightly test -p auto_enums --all-features --test compiletest -- --ignored
+# RUSTFLAGS='--cfg auto_enums_def_site_enum_ident' cargo +nightly test -p auto_enums --all-features --test compiletest -- --ignored

--- a/core/src/auto_enum/mod.rs
+++ b/core/src/auto_enum/mod.rs
@@ -123,6 +123,9 @@ fn expand_parent_local(local: &mut Local, cx: &mut Context) -> Result<()> {
 }
 
 fn expand_parent_item_fn(item: &mut ItemFn, cx: &mut Context) -> Result<()> {
+    #[cfg(auto_enums_def_site_enum_ident)]
+    cx.update_enum_ident(item);
+
     let ItemFn { sig, block, .. } = item;
     if let ReturnType::Type(_, ty) = &mut sig.output {
         match &**ty {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,15 @@
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::use_self)]
+// `auto_enum` uses the hash value of the input AST to prevent access to the generated enum.
+// This works well for common use cases, but is inconvenient when testing error messages that contain enum names.
+// When this feature is enabled, `auto_enum` uses the enum name is based on the function name,
+// and access to the enum is prevented by using `Span::def_site()`.
+// Currently, this feature only affects when `auto_enum` is used in function position.
+//
+// This is disabled by default and can be enabled using
+// `--cfg auto_enums_def_site_enum_ident` in RUSTFLAGS.
+#![cfg_attr(auto_enums_def_site_enum_ident, feature(proc_macro_def_site))]
 
 extern crate proc_macro;
 

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,7 +1,9 @@
+#![cfg(auto_enums_def_site_enum_ident)]
 #![cfg(all(feature = "std", feature = "type_analysis", feature = "transpose_methods"))]
 #![warn(unsafe_code)]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 
+#[ignore]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -288,10 +288,7 @@ fn nested() {
     fn match_nop(x: usize) -> impl Iterator<Item = i32> {
         match x {
             0 => 1..8,
-            3 => {
-                // #[nested] // no-op, E0308 error will occur if you uncomment this
-                2..=10
-            }
+            3 => 2..=10,
             _ => (0..2).map(|x| x + 1),
         }
     }
@@ -301,7 +298,6 @@ fn nested() {
         if x == 0 {
             1..8
         } else if x > 3 {
-            // #[nested] // no-op, E0308 error will occur if you uncomment this
             2..=10
         } else {
             (0..2).map(|x| x + 1)

--- a/tests/ui/auto_enum/compile-fail.stderr
+++ b/tests/ui/auto_enum/compile-fail.stderr
@@ -31,10 +31,17 @@ error: `#[auto_enum]` is required two or more branches or marker macros in total
    | |______^
 
 error[E0061]: this function takes 1 parameter but 2 parameters were supplied
- --> $DIR/compile-fail.rs:3:1
-  |
-3 | #[auto_enum(Iterator)]
-  | ^^^^^^^^^^^^^^^^^^^^^^
-  | |
-  | defined here
-  | expected 1 parameter
+  --> $DIR/compile-fail.rs:3:1
+   |
+3  |   #[auto_enum(Iterator)]
+   |   ^---------------------
+   |   |
+   |  _defined here
+   | |
+4  | | fn unexpected_token_in_marker(x: usize) -> impl Iterator<Item = i32> {
+5  | |     match x {
+6  | |         0 => marker!(1..8..), //~ ERROR expected one of `)`, `,`, `.`, `?`, or an operator, found `..`
+...  |
+37 | | fn return0(x: i32, y: i32) -> impl Iterator<Item = i32> {
+38 | |     #[auto_enum(Iterator)]
+   | |_^ expected 1 parameter

--- a/tests/ui/auto_enum/def_site.rs
+++ b/tests/ui/auto_enum/def_site.rs
@@ -1,0 +1,15 @@
+use auto_enums::auto_enum;
+
+#[auto_enum(Iterator)]
+fn def_site(x: usize) -> impl Iterator<Item = i32> {
+    match x {
+        0 => 1..8,
+        3 => {
+            #[never]
+            return __Enumdef_site::__Variant0(2..4);
+        }
+        _ => (0..2).map(|x| x + 1),
+    }
+}
+
+fn main() {}

--- a/tests/ui/auto_enum/def_site.stderr
+++ b/tests/ui/auto_enum/def_site.stderr
@@ -1,0 +1,5 @@
+error[E0433]: failed to resolve: use of undeclared type or module `__Enumdef_site`
+ --> $DIR/def_site.rs:9:20
+  |
+9 |             return __Enumdef_site::__Variant0(2..4);
+  |                    ^^^^^^^^^^^^^^ use of undeclared type or module `__Enumdef_site`

--- a/tests/ui/auto_enum/nested.rs
+++ b/tests/ui/auto_enum/nested.rs
@@ -1,0 +1,29 @@
+use auto_enums::auto_enum;
+
+#[auto_enum(Iterator)]
+fn match_nop(x: usize) -> impl Iterator<Item = i32> {
+    match x {
+        0 => 1..8,
+        3 => {
+            // This strange formatting is a rustfmt bug.
+#[nested] //~ ERROR E0308
+            2..=10
+        }
+        _ => (0..2).map(|x| x + 1),
+    }
+}
+
+#[auto_enum(Iterator)]
+fn if_nop(x: usize) -> impl Iterator<Item = i32> {
+    if x == 0 {
+        1..8
+    } else if x > 3 {
+        // This strange formatting is a rustfmt bug.
+#[nested] //~ ERROR E0308
+        2..=10
+    } else {
+        (0..2).map(|x| x + 1)
+    }
+}
+
+fn main() {}

--- a/tests/ui/auto_enum/nested.stderr
+++ b/tests/ui/auto_enum/nested.stderr
@@ -1,0 +1,37 @@
+error[E0308]: match arms have incompatible types
+  --> $DIR/nested.rs:10:13
+   |
+3  |  / #[auto_enum(Iterator)]
+4  |  | fn match_nop(x: usize) -> impl Iterator<Item = i32> {
+5  |  |     match x {
+   |  |_____-
+6  | ||         0 => 1..8,
+7  | ||         3 => {
+8  | ||             // This strange formatting is a rustfmt bug.
+9  | || #[nested] //~ ERROR E0308
+10 | ||             2..=10
+   | ||             ^^^^^^ expected enum `match_nop::__Enummatch_nop`, found struct `std::ops::RangeInclusive`
+11 | ||         }
+12 | ||         _ => (0..2).map(|x| x + 1),
+13 | ||     }
+   | ||_____- `match` arms have incompatible types
+...   |
+   |
+   = note: expected type `match_nop::__Enummatch_nop<std::ops::Range<{integer}>, _>`
+              found type `std::ops::RangeInclusive<{integer}>`
+
+error[E0308]: if and else have incompatible types
+  --> $DIR/nested.rs:16:22
+   |
+16 |   #[auto_enum(Iterator)]
+   |  ______________________^
+17 | | fn if_nop(x: usize) -> impl Iterator<Item = i32> {
+18 | |     if x == 0 {
+19 | |         1..8
+...  |
+23 | |         2..=10
+   | |         ------ expected because of this
+...  |
+   |
+   = note: expected type `std::ops::RangeInclusive<{integer}>`
+              found type `if_nop::__Enumif_nop<_, std::iter::Map<std::ops::Range<{integer}>, [closure@$DIR/tests/ui/auto_enum/nested.rs:25:20: 25:29]>>`


### PR DESCRIPTION
`auto_enum` uses the hash value of the input AST to prevent access to
the generated enum.
This works well for common use cases, but is inconvenient when testing
error messages that contain enum names.
This PR introduces an unstable cfg flag that depends on the unstable
`proc_macro_def_site` feature. When this feature is enabled, `auto_enum`
uses the enum name is based on the function name, and access to the enum
is prevented by using `Span::def_site()`.
Currently, this feature only affects when `auto_enum` is used in
function position.