### PR TITLE
Remove #![warn(clippy::pedantic)]

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,8 +10,7 @@
 #![warn(rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because these lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::use_self)]
+#![warn(clippy::all)]
 // `auto_enum` uses the hash value of the input AST to prevent access to the generated enum.
 // This works well for common use cases, but is inconvenient when testing error messages that contain enum names.
 // When this feature is enabled, `auto_enum` uses the enum name is based on the function name,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -8,8 +8,7 @@
 ))]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, single_use_lifetimes, unreachable_pub)]
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::use_self)]
+#![warn(clippy::all)]
 
 #[cfg(all(feature = "futures", not(feature = "unstable")))]
 compile_error!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -757,8 +757,7 @@
 ))]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, single_use_lifetimes, unreachable_pub)]
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::use_self)]
+#![warn(clippy::all)]
 
 #[cfg(all(feature = "futures", not(feature = "unstable")))]
 compile_error!(


### PR DESCRIPTION
I think pedantic lints are no longer useful.
