### PR TITLE
Fix unused braces warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
       - name: cargo doc
         if: matrix.component == 'rustdoc'
         env:
-          RUSTDOCFLAGS: -Dwarnings
+          # TODO: once https://github.com/rust-lang/rust/issues/70814 fixed, remove '-Aunused_braces'
+          RUSTDOCFLAGS: -Dwarnings -Aunused_braces
         run: |
           cargo doc --no-deps --all --all-features

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -53,7 +53,11 @@ pub(crate) fn replace_expr(this: &mut Expr, f: impl FnOnce(Expr) -> Expr) {
 }
 
 pub(crate) fn replace_block(this: &mut Block, f: impl FnOnce(Block) -> Expr) {
-    *this = block(vec![Stmt::Expr(f(mem::replace(this, block(Vec::new()))))]);
+    // `brace_token` of the block that passed to `f` should have `call_site` span.
+    // If `f` generates unused braces containing the span of `this.brace_token`,
+    // this will cause confusing warnings: https://github.com/rust-lang/rust/issues/71080
+    let stmts = mem::replace(&mut this.stmts, Vec::new());
+    this.stmts = vec![Stmt::Expr(f(block(stmts)))];
 }
 
 // =================================================================================================

--- a/tests/auto_enum.rs
+++ b/tests/auto_enum.rs
@@ -31,8 +31,10 @@ mod stable {
 
         // block + unsafe block + parentheses
         #[rustfmt::skip]
+        #[allow(unknown_lints)]
         #[allow(unsafe_code)]
         #[allow(unused_parens)]
+        #[allow(unused_braces)]
         #[allow(unused_unsafe)]
         #[auto_enum(Iterator)]
         fn block(x: usize) -> impl Iterator<Item = i32> {

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -43,8 +43,10 @@ fn nested() {
     }
 
     #[rustfmt::skip]
+    #[allow(unknown_lints)]
     #[allow(unsafe_code)]
     #[allow(unused_unsafe)]
+    #[allow(unused_braces)]
     #[auto_enum(Iterator)]
     fn in_block(x: usize) -> impl Iterator<Item = i32> {
         {{{ unsafe {{{ unsafe { unsafe {{

--- a/tests/ui/auto_enum/nested.stderr
+++ b/tests/ui/auto_enum/nested.stderr
@@ -23,14 +23,21 @@ error[E0308]: `match` arms have incompatible types
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/nested.rs:16:1
    |
-16 | / #[auto_enum(Iterator)]
-17 | | fn if_nop(x: usize) -> impl Iterator<Item = i32> {
-18 | |     if x == 0 {
-19 | |         1..8
-...  |
-23 | |         2..=10
-   | |         ------ expected because of this
-...  |
+16 |  / #[auto_enum(Iterator)]
+17 |  | fn if_nop(x: usize) -> impl Iterator<Item = i32> {
+18 |  |     if x == 0 {
+19 |  |         1..8
+20 |  |     } else if x > 3 {
+   |  |____________-
+21 | ||         // This strange formatting is a rustfmt bug.
+22 | || #[nested] //~ ERROR E0308
+23 | ||         2..=10
+   | ||         ------ expected because of this
+24 | ||     } else {
+25 | ||         (0..2).map(|x| x + 1)
+26 | ||     }
+   | ||_____- `if` and `else` have incompatible types
+...   |
    |
    = note: expected type `std::ops::RangeInclusive<{integer}>`
               found enum `if_nop::__Enumif_nop<_, std::iter::Map<std::ops::Range<{integer}>, [closure@$DIR/tests/ui/auto_enum/nested.rs:25:20: 25:29]>>`

--- a/tests/ui/auto_enum/rejected-by-rustc.stderr
+++ b/tests/ui/auto_enum/rejected-by-rustc.stderr
@@ -12,10 +12,4 @@ help: try placing this code inside a block
 10|     } }
   |
 
-error: attributes are not yet allowed on `if` expressions
-  --> $DIR/rejected-by-rustc.rs:18:9
-   |
-18 |         #[nested]
-   |         ^^^^^^^^^
-
 error: `#[auto_enum]` is required two or more branches or marker macros in total, there is no branch or marker macro in this statement


### PR DESCRIPTION
Basically due to this function:

https://github.com/taiki-e/auto_enums/blob/f77fd83a2b2c1b694cdc23cad0d301a7402c12b7/core/src/utils.rs#L55-L57

`brace_token` of the block that passed to `f` should have `call_site` span.
If `f` generates unused braces containing the span of `this.brace_token`, 
this will cause confusing warnings: https://github.com/rust-lang/rust/issues/71080