### PR TITLE
Remove #[inline] attribute from generated code

### DIFF
--- a/derive/src/derive/core/convert/as_mut.rs
+++ b/derive/src/derive/core/convert/as_mut.rs
@@ -8,7 +8,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::convert::AsMut)?,
         parse_quote! {
             trait AsMut<__T: ?Sized> {
-                #[inline]
                 fn as_mut(&mut self) -> &mut __T;
             }
         }?,

--- a/derive/src/derive/core/convert/as_ref.rs
+++ b/derive/src/derive/core/convert/as_ref.rs
@@ -8,7 +8,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::convert::AsRef)?,
         parse_quote! {
             trait AsRef<__T: ?Sized> {
-                #[inline]
                 fn as_ref(&self) -> &__T;
             }
         }?,

--- a/derive/src/derive/core/fmt/mod.rs
+++ b/derive/src/derive/core/fmt/mod.rs
@@ -11,7 +11,6 @@ macro_rules! fmt_impl {
                     parse_quote!(::core::fmt::$Trait)?,
                     parse_quote! {
                         trait $Trait {
-                            #[inline]
                             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result;
                         }
                     }?,

--- a/derive/src/derive/core/fmt/write.rs
+++ b/derive/src/derive/core/fmt/write.rs
@@ -8,11 +8,8 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::fmt::Write)?,
         parse_quote! {
             trait Write {
-                #[inline]
                 fn write_str(&mut self, s: &str) -> ::core::fmt::Result;
-                #[inline]
                 fn write_char(&mut self, c: char) -> ::core::fmt::Result;
-                #[inline]
                 fn write_fmt(&mut self, args: ::core::fmt::Arguments<'_>) -> ::core::fmt::Result;
             }
         }?,

--- a/derive/src/derive/core/future.rs
+++ b/derive/src/derive/core/future.rs
@@ -9,7 +9,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote! {
             trait Future {
                 type Output;
-                #[inline]
                 fn poll(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,

--- a/derive/src/derive/core/iter/double_ended_iterator.rs
+++ b/derive/src/derive/core/iter/double_ended_iterator.rs
@@ -7,11 +7,9 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
 
     // It is equally efficient if `try_rfold` can be used.
     let try_trait = quote! {
-        #[inline]
         fn rfold<__U, __F>(self, accum: __U, f: __F) -> __U
         where
             __F: ::core::ops::FnMut(__U, Self::Item) -> __U;
-        #[inline]
         fn rfind<__P>(&mut self, predicate: __P) -> ::core::option::Option<Self::Item>
         where
             __P: ::core::ops::FnMut(&Self::Item) -> bool;
@@ -23,7 +21,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::iter::DoubleEndedIterator)?,
         parse_quote! {
             trait DoubleEndedIterator: ::core::iter::Iterator {
-                #[inline]
                 fn next_back(&mut self) -> ::core::option::Option<Self::Item>;
                 #try_trait
             }

--- a/derive/src/derive/core/iter/exact_size_iterator.rs
+++ b/derive/src/derive/core/iter/exact_size_iterator.rs
@@ -11,7 +11,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::iter::ExactSizeIterator)?,
         parse_quote! {
             trait ExactSizeIterator: ::core::iter::Iterator {
-                #[inline]
                 fn len(&self) -> usize;
             }
         }?,

--- a/derive/src/derive/core/iter/extend.rs
+++ b/derive/src/derive/core/iter/extend.rs
@@ -8,7 +8,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::iter::Extend)?,
         parse_quote! {
             trait Extend<__A> {
-                #[inline]
                 fn extend<__T: ::core::iter::IntoIterator<Item = __A>>(&mut self, iter: __T);
             }
         }?,

--- a/derive/src/derive/core/iter/iterator.rs
+++ b/derive/src/derive/core/iter/iterator.rs
@@ -7,15 +7,12 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
 
     // It is equally efficient if `try_fold` can be used.
     let try_trait = quote! {
-        #[inline]
         fn fold<__U, __F>(self, init: __U, f: __F) -> __U
         where
             __F: ::core::ops::FnMut(__U, Self::Item) -> __U;
-        #[inline]
         fn find<__P>(&mut self, predicate: __P) -> ::core::option::Option<Self::Item>
         where
             __P: ::core::ops::FnMut(&Self::Item) -> bool;
-        #[inline]
         fn find_map<__U, __F>(&mut self, f: __F) -> ::core::option::Option<__U>
         where
             __F: ::core::ops::FnMut(Self::Item) -> ::core::option::Option<__U>;
@@ -27,15 +24,10 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote! {
             trait Iterator {
                 type Item;
-                #[inline]
                 fn next(&mut self) -> ::core::option::Option<Self::Item>;
-                #[inline]
                 fn size_hint(&self) -> (usize, ::core::option::Option<usize>);
-                #[inline]
                 fn count(self) -> usize;
-                #[inline]
                 fn last(self) -> ::core::option::Option<Self::Item>;
-                #[inline]
                 #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
                 fn collect<__U: ::core::iter::FromIterator<Self::Item>>(self) -> __U;
                 #try_trait

--- a/derive/src/derive/core/ops/deref.rs
+++ b/derive/src/derive/core/ops/deref.rs
@@ -9,7 +9,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote! {
             trait Deref {
                 type Target;
-                #[inline]
                 fn deref(&self) -> &Self::Target;
             }
         }?,

--- a/derive/src/derive/core/ops/deref_mut.rs
+++ b/derive/src/derive/core/ops/deref_mut.rs
@@ -9,7 +9,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::ops::DerefMut)?,
         parse_quote! {
             trait DerefMut: ::core::ops::Deref {
-                #[inline]
                 fn deref_mut(&mut self) -> &mut Self::Target;
             }
         }?,

--- a/derive/src/derive/core/ops/fn_.rs
+++ b/derive/src/derive/core/ops/fn_.rs
@@ -21,7 +21,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         .try_for_each(|f| parse_quote!(#f: #trait_).map(|f| impl_.push_where_predicate(f)))?;
 
     impl_.push_method(parse_quote! {
-        #[inline]
         extern "rust-call" fn call(&self, args: (__T,)) -> Self::Output;
     }?)?;
 

--- a/derive/src/derive/core/ops/fn_mut.rs
+++ b/derive/src/derive/core/ops/fn_mut.rs
@@ -21,7 +21,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         .try_for_each(|f| parse_quote!(#f: #trait_).map(|f| impl_.push_where_predicate(f)))?;
 
     impl_.push_method(parse_quote! {
-        #[inline]
         extern "rust-call" fn call_mut(&mut self, args: (__T,)) -> Self::Output;
     }?)?;
 

--- a/derive/src/derive/core/ops/fn_once.rs
+++ b/derive/src/derive/core/ops/fn_once.rs
@@ -23,7 +23,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
     impl_.append_items_from_trait(parse_quote! {
         trait FnOnce {
             type Output;
-            #[inline]
             extern "rust-call" fn call_once(self, args: (__T,)) -> Self::Output;
         }
     }?)?;

--- a/derive/src/derive/core/ops/generator.rs
+++ b/derive/src/derive/core/ops/generator.rs
@@ -10,7 +10,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
             trait Generator<R> {
                 type Yield;
                 type Return;
-                #[inline]
                 fn resume(
                     self: ::core::pin::Pin<&mut Self>,
                     arg: R,

--- a/derive/src/derive/core/ops/index.rs
+++ b/derive/src/derive/core/ops/index.rs
@@ -9,7 +9,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote! {
             trait Index<__Idx> {
                 type Output;
-                #[inline]
                 fn index(&self, index: __Idx) -> &Self::Output;
             }
         }?,

--- a/derive/src/derive/core/ops/index_mut.rs
+++ b/derive/src/derive/core/ops/index_mut.rs
@@ -9,7 +9,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::ops::IndexMut)?,
         parse_quote! {
             trait IndexMut<__Idx>: ::core::ops::Index<__Idx> {
-                #[inline]
                 fn index_mut(&mut self, index: __Idx) -> &mut Self::Output;
             }
         }?,

--- a/derive/src/derive/core/ops/range_bounds.rs
+++ b/derive/src/derive/core/ops/range_bounds.rs
@@ -8,9 +8,7 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::core::ops::RangeBounds)?,
         parse_quote! {
             trait RangeBounds<__T: ?Sized> {
-                #[inline]
                 fn start_bound(&self) -> ::core::ops::Bound<&__T>;
-                #[inline]
                 fn end_bound(&self) -> ::core::ops::Bound<&__T>;
             }
         }?,

--- a/derive/src/derive/external/futures01/future.rs
+++ b/derive/src/derive/external/futures01/future.rs
@@ -12,7 +12,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
             trait Future {
                 type Item;
                 type Error;
-                #[inline]
                 fn poll(&mut self) -> #crate_::Poll<Self::Item, Self::Error>;
             }
         }?,

--- a/derive/src/derive/external/futures01/sink.rs
+++ b/derive/src/derive/external/futures01/sink.rs
@@ -12,11 +12,8 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
             trait Sink {
                 type SinkItem;
                 type SinkError;
-                #[inline]
                 fn start_send(&mut self, item: Self::SinkItem) -> #crate_::StartSend<Self::SinkItem, Self::SinkError>;
-                #[inline]
                 fn poll_complete(&mut self) -> #crate_::Poll<(), Self::SinkError>;
-                #[inline]
                 fn close(&mut self) -> #crate_::Poll<(), Self::SinkError>;
             }
         }?,

--- a/derive/src/derive/external/futures01/stream.rs
+++ b/derive/src/derive/external/futures01/stream.rs
@@ -12,7 +12,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
             trait Stream {
                 type Item;
                 type Error;
-                #[inline]
                 fn poll(&mut self) -> #crate_::Poll<::core::option::Option<Self::Item>, Self::Error>;
             }
         }?,

--- a/derive/src/derive/external/futures03/async_buf_read.rs
+++ b/derive/src/derive/external/futures03/async_buf_read.rs
@@ -8,12 +8,10 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::futures::io::AsyncBufRead)?,
         parse_quote! {
             trait AsyncBufRead {
-                #[inline]
                 fn poll_fill_buf<'__a>(
                     self: ::core::pin::Pin<&'__a mut Self>,
                     cx: &mut ::core::task::Context<'_>,
                 ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>>;
-                #[inline]
                 fn consume(self: ::core::pin::Pin<&mut Self>, amt: usize);
             }
         }?,

--- a/derive/src/derive/external/futures03/async_read.rs
+++ b/derive/src/derive/external/futures03/async_read.rs
@@ -8,13 +8,11 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::futures::io::AsyncRead)?,
         parse_quote! {
             trait AsyncRead {
-                #[inline]
                 fn poll_read(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,
                     buf: &mut [u8],
                 ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                #[inline]
                 fn poll_read_vectored(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,

--- a/derive/src/derive/external/futures03/async_seek.rs
+++ b/derive/src/derive/external/futures03/async_seek.rs
@@ -8,7 +8,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::futures::io::AsyncSeek)?,
         parse_quote! {
             trait AsyncSeek {
-                #[inline]
                 fn poll_seek(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,

--- a/derive/src/derive/external/futures03/async_write.rs
+++ b/derive/src/derive/external/futures03/async_write.rs
@@ -8,24 +8,20 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::futures::io::AsyncWrite)?,
         parse_quote! {
             trait AsyncWrite {
-                #[inline]
                 fn poll_write(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,
                     buf: &[u8],
                 ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                #[inline]
                 fn poll_write_vectored(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,
                     bufs: &[::std::io::IoSlice<'_>],
                 ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                #[inline]
                 fn poll_flush(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,
                 ) -> ::core::task::Poll<::std::io::Result<()>>;
-                #[inline]
                 fn poll_close(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,

--- a/derive/src/derive/external/futures03/sink.rs
+++ b/derive/src/derive/external/futures03/sink.rs
@@ -9,22 +9,18 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote! {
             trait Sink<Item> {
                 type Error;
-                #[inline]
                 fn poll_ready(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,
                 ) -> ::core::task::Poll<::core::result::Result<(), Self::Error>>;
-                #[inline]
                 fn start_send(
                     self: ::core::pin::Pin<&mut Self>,
                     item: Item,
                 ) -> ::core::result::Result<(), Self::Error>;
-                #[inline]
                 fn poll_flush(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,
                 ) -> ::core::task::Poll<::core::result::Result<(), Self::Error>>;
-                #[inline]
                 fn poll_close(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,

--- a/derive/src/derive/external/futures03/stream.rs
+++ b/derive/src/derive/external/futures03/stream.rs
@@ -9,12 +9,10 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote! {
             trait Stream {
                 type Item;
-                #[inline]
                 fn poll_next(
                     self: ::core::pin::Pin<&mut Self>,
                     cx: &mut ::core::task::Context<'_>,
                 ) -> ::core::task::Poll<::core::option::Option<Self::Item>>;
-                #[inline]
                 fn size_hint(&self) -> (usize, ::core::option::Option<usize>);
             }
         }?,

--- a/derive/src/derive/external/rayon/indexed_par_iter.rs
+++ b/derive/src/derive/external/rayon/indexed_par_iter.rs
@@ -11,13 +11,10 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(#iter::IndexedParallelIterator)?,
         parse_quote! {
             trait IndexedParallelIterator: #iter::ParallelIterator {
-                #[inline]
                 fn drive<__C>(self, consumer: __C) -> __C::Result
                 where
                     __C: #iter::plumbing::Consumer<Self::Item>;
-                #[inline]
                 fn len(&self) -> usize;
-                #[inline]
                 fn with_producer<__CB>(self, callback: __CB) -> __CB::Output
                 where
                     __CB: #iter::plumbing::ProducerCallback<Self::Item>;

--- a/derive/src/derive/external/rayon/par_extend.rs
+++ b/derive/src/derive/external/rayon/par_extend.rs
@@ -10,7 +10,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(#iter::ParallelExtend)?,
         parse_quote! {
             trait ParallelExtend<__T: Send> {
-                #[inline]
                 fn par_extend<__I>(&mut self, par_iter: __I)
                 where
                     __I: #iter::IntoParallelIterator<Item = __T>;

--- a/derive/src/derive/external/rayon/par_iter.rs
+++ b/derive/src/derive/external/rayon/par_iter.rs
@@ -11,11 +11,9 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote! {
             trait ParallelIterator {
                 type Item;
-                #[inline]
                 fn drive_unindexed<__C>(self, consumer: __C) -> __C::Result
                 where
                     __C: #iter::plumbing::UnindexedConsumer<Self::Item>;
-                #[inline]
                 fn opt_len(&self) -> ::core::option::Option<usize>;
             }
         }?,

--- a/derive/src/derive/external/serde/serialize.rs
+++ b/derive/src/derive/external/serde/serialize.rs
@@ -10,7 +10,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(#ser::Serialize)?,
         parse_quote! {
             trait Serialize {
-                #[inline]
                 fn serialize<__S>(&self, serializer: __S) -> ::core::result::Result<__S::Ok, __S::Error>
                 where
                     __S: #ser::Serializer;

--- a/derive/src/derive/std/io/buf_read.rs
+++ b/derive/src/derive/std/io/buf_read.rs
@@ -8,13 +8,9 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::std::io::BufRead)?,
         parse_quote! {
             trait BufRead {
-                #[inline]
                 fn fill_buf(&mut self) -> ::std::io::Result<&[u8]>;
-                #[inline]
                 fn consume(&mut self, amt: usize);
-                #[inline]
                 fn read_until(&mut self, byte: u8, buf: &mut ::std::vec::Vec<u8>) -> ::std::io::Result<usize>;
-                #[inline]
                 fn read_line(&mut self, buf: &mut ::std::string::String) -> ::std::io::Result<usize>;
             }
         }?,

--- a/derive/src/derive/std/io/read.rs
+++ b/derive/src/derive/std/io/read.rs
@@ -7,7 +7,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
     let vectored = quote!();
     #[cfg(stable_1_36)]
     let vectored = quote! {
-        #[inline]
         fn read_vectored(&mut self, bufs: &mut [::std::io::IoSliceMut<'_>]) -> ::std::io::Result<usize>;
     };
 
@@ -18,13 +17,9 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::std::io::Read)?,
         parse_quote! {
             trait Read {
-                #[inline]
                 fn read(&mut self, buf: &mut [u8]) -> ::std::io::Result<usize>;
-                #[inline]
                 fn read_to_end(&mut self, buf: &mut ::std::vec::Vec<u8>) -> ::std::io::Result<usize>;
-                #[inline]
                 fn read_to_string(&mut self, buf: &mut ::std::string::String) -> ::std::io::Result<usize>;
-                #[inline]
                 fn read_exact(&mut self, buf: &mut [u8]) -> ::std::io::Result<()>;
                 #vectored
             }

--- a/derive/src/derive/std/io/seek.rs
+++ b/derive/src/derive/std/io/seek.rs
@@ -8,7 +8,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::std::io::Seek)?,
         parse_quote! {
             trait Seek {
-                #[inline]
                 fn seek(&mut self, pos: ::std::io::SeekFrom) -> ::std::io::Result<u64>;
             }
         }?,

--- a/derive/src/derive/std/io/write.rs
+++ b/derive/src/derive/std/io/write.rs
@@ -7,7 +7,6 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
     let vectored = quote!();
     #[cfg(stable_1_36)]
     let vectored = quote! {
-        #[inline]
         fn write_vectored(&mut self, bufs: &[::std::io::IoSlice<'_>]) -> ::std::io::Result<usize>;
     };
 
@@ -16,13 +15,9 @@ pub(crate) fn derive(data: &Data, items: &mut Vec<ItemImpl>) -> Result<()> {
         parse_quote!(::std::io::Write)?,
         parse_quote! {
             trait Write {
-                #[inline]
                 fn write(&mut self, buf: &[u8]) -> ::std::io::Result<usize>;
-                #[inline]
                 fn flush(&mut self) -> ::std::io::Result<()>;
-                #[inline]
                 fn write_all(&mut self, buf: &[u8]) -> ::std::io::Result<()>;
-                #[inline]
                 fn write_fmt(&mut self, fmt: ::std::fmt::Arguments<'_>) -> ::std::io::Result<()>;
                 #vectored
             }

--- a/derive/src/derive/ty_impls/transpose.rs
+++ b/derive/src/derive/ty_impls/transpose.rs
@@ -40,7 +40,6 @@ fn transpose_option(data: &Data) -> Result<ItemImpl> {
     let transpose = data.variants().iter().map(|v| quote!(#ident::#v(x) => x.map(#ident::#v)));
 
     items.push_item(parse_quote! {
-        #[inline]
         fn transpose(self) -> ::core::option::Option<#ident<#(#fields),*>> {
             match self { #(#transpose,)* }
         }
@@ -73,7 +72,6 @@ fn transpose_result(data: &Data) -> Result<ItemImpl> {
         .map(|v| quote!(#ident::#v(x) => x.map(#ident::#v).map_err(#ident::#v)));
 
     items.push_item(parse_quote! {
-        #[inline]
         fn transpose(self) -> ::core::result::Result<#ident<#(#fields),*>, #ident<#(#err_fields),*>> {
             match self { #(#transpose,)* }
         }
@@ -95,7 +93,6 @@ fn transpose_ok(data: &Data) -> Result<ItemImpl> {
 
     let transpose = data.variants().iter().map(|v| quote!(#ident::#v(x) => x.map(#ident::#v)));
     items.push_item(parse_quote! {
-        #[inline]
         fn transpose_ok(self) -> ::core::result::Result<#ident<#(#fields),*>, __E> {
             match self { #(#transpose,)* }
         }
@@ -117,7 +114,6 @@ fn transpose_err(data: &Data) -> Result<ItemImpl> {
 
     let transpose = data.variants().iter().map(|v| quote!(#ident::#v(x) => x.map_err(#ident::#v)));
     items.push_item(parse_quote! {
-        #[inline]
         fn transpose_err(self) -> ::core::result::Result<__T, #ident<#(#fields),*>> {
             match self { #(#transpose,)* }
         }

--- a/docs/example-1.md
+++ b/docs/example-1.md
@@ -11,14 +11,12 @@ fn foo(x: i32) -> impl Iterator<Item = i32> {
         __T2: ::core::iter::Iterator<Item = <__T1 as ::core::iter::Iterator>::Item>,
     {
         type Item = <__T1 as ::core::iter::Iterator>::Item;
-        #[inline]
         fn next(&mut self) -> ::core::option::Option<Self::Item> {
             match self {
                 __Enum1::__T1(x) => x.next(),
                 __Enum1::__T2(x) => x.next(),
             }
         }
-        #[inline]
         fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
             match self {
                 __Enum1::__T1(x) => x.size_hint(),

--- a/docs/supported_traits/external/futures/AsyncBufRead.md
+++ b/docs/supported_traits/external/futures/AsyncBufRead.md
@@ -24,7 +24,6 @@ where
     A: ::futures::io::AsyncBufRead,
     B: ::futures::io::AsyncBufRead,
 {
-    #[inline]
       fn poll_fill_buf<'__a>(
         self: ::core::pin::Pin<&'__a mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -35,7 +34,6 @@ where
         }
     }
 
-    #[inline]
     fn consume(self: ::core::pin::Pin<&mut Self>, amt: usize) {
         match ::core::pin::Pin::get_unchecked_mut(self) {
             Enum::A(x) => ::futures::io::AsyncBufRead::consume(::core::pin::Pin::new_unchecked(x), amt),

--- a/docs/supported_traits/external/futures/AsyncRead.md
+++ b/docs/supported_traits/external/futures/AsyncRead.md
@@ -24,7 +24,6 @@ where
     A: ::futures::io::AsyncRead,
     B: ::futures::io::AsyncRead,
 {
-    #[inline]
     fn poll_read(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -38,7 +37,6 @@ where
         }
     }
 
-    #[inline]
     fn poll_read_vectored(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,

--- a/docs/supported_traits/external/futures/AsyncSeek.md
+++ b/docs/supported_traits/external/futures/AsyncSeek.md
@@ -24,7 +24,6 @@ where
     A: ::futures::io::AsyncSeek,
     B: ::futures::io::AsyncSeek,
 {
-    #[inline]
     fn poll_seek(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,

--- a/docs/supported_traits/external/futures/AsyncWrite.md
+++ b/docs/supported_traits/external/futures/AsyncWrite.md
@@ -24,7 +24,6 @@ where
     A: ::futures::io::AsyncWrite,
     B: ::futures::io::AsyncWrite,
 {
-    #[inline]
     fn poll_write(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -38,7 +37,6 @@ where
         }
     }
 
-    #[inline]
     fn poll_write_vectored(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -52,7 +50,6 @@ where
         }
     }
 
-    #[inline]
     fn poll_flush(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -65,7 +62,6 @@ where
         }
     }
 
-    #[inline]
     fn poll_close(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,

--- a/docs/supported_traits/external/futures/sink.md
+++ b/docs/supported_traits/external/futures/sink.md
@@ -26,7 +26,6 @@ where
 {
     type Error = <A as ::futures::sink::Sink>::Error;
 
-    #[inline]
     fn poll_ready(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -39,7 +38,6 @@ where
         }
     }
 
-    #[inline]
     fn start_send(
         self: ::core::pin::Pin<&mut Self>,
         item: Item,
@@ -52,7 +50,6 @@ where
         }
     }
 
-    #[inline]
     fn poll_flush(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -65,7 +62,6 @@ where
         }
     }
 
-    #[inline]
     fn poll_close(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,

--- a/docs/supported_traits/external/futures/stream.md
+++ b/docs/supported_traits/external/futures/stream.md
@@ -26,7 +26,6 @@ where
 {
     type Item = <A as ::futures::stream::Stream>::Item;
 
-    #[inline]
     fn poll_next(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -39,7 +38,6 @@ where
         }
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
         match self {
             Enum::A(x) => ::futures::stream::Stream::size_hint(x),

--- a/docs/supported_traits/external/rayon/IndexedParallelIterator.md
+++ b/docs/supported_traits/external/rayon/IndexedParallelIterator.md
@@ -23,7 +23,6 @@ where
     A: ::rayon::iter::IndexedParallelIterator,
     B: ::rayon::iter::IndexedParallelIterator<Item = <A as ::rayon::iter::ParallelIterator>::Item>,
 {
-    #[inline]
     fn drive<__C>(self, consumer: __C) -> __C::Result
     where
         __C: ::rayon::iter::plumbing::Consumer<Self::Item>,
@@ -34,7 +33,6 @@ where
         }
     }
 
-    #[inline]
     fn len(&self) -> usize {
         match self {
             Enum::A(x) => ::rayon::iter::IndexedParallelIterator::len(x),
@@ -42,7 +40,6 @@ where
         }
     }
 
-    #[inline]
     fn with_producer<__CB>(self, callback: __CB) -> __CB::Output
     where
         __CB: ::rayon::iter::plumbing::ProducerCallback<Self::Item>,

--- a/docs/supported_traits/external/rayon/ParallelExtend.md
+++ b/docs/supported_traits/external/rayon/ParallelExtend.md
@@ -23,7 +23,6 @@ where
     A: ::rayon::iter::ParallelExtend<__T>,
     B: ::rayon::iter::ParallelExtend<__T>,
 {
-    #[inline]
     fn par_extend<__I>(&mut self, par_iter: __I)
     where
         __I: ::rayon::IntoParallelIterator<Item = __T>

--- a/docs/supported_traits/external/rayon/ParallelIterator.md
+++ b/docs/supported_traits/external/rayon/ParallelIterator.md
@@ -25,7 +25,6 @@ where
 {
     type Item = <A as ::rayon::iter::ParallelIterator>::Item;
 
-    #[inline]
     fn drive_unindexed<__C>(self, consumer: __C) -> __C::Result
     where
         __C: ::rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
@@ -36,7 +35,6 @@ where
         }
     }
 
-    #[inline]
     fn opt_len(&self) -> ::core::option::Option<usize> {
         match self {
             Enum::A(x) => ::rayon::iter::ParallelIterator::opt_len(x),

--- a/docs/supported_traits/external/serde/serialize.md
+++ b/docs/supported_traits/external/serde/serialize.md
@@ -25,7 +25,6 @@ where
     A: ::serde::ser::Serialize,
     B: ::serde::ser::Serialize,
 {
-    #[inline]
     fn serialize<__S>(&self, serializer: __S) -> ::std::result::Result<__S::Ok, __S::Error>
     where
         __S: ::serde::ser::Serializer

--- a/docs/supported_traits/std/future.md
+++ b/docs/supported_traits/std/future.md
@@ -26,7 +26,6 @@ where
 {
     type Output = <A as ::core::future::Future>::Output;
 
-    #[inline]
     fn poll(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,

--- a/docs/supported_traits/std/io/BufRead.md
+++ b/docs/supported_traits/std/io/BufRead.md
@@ -23,7 +23,6 @@ where
     A: ::std::io::BufRead,
     B: ::std::io::BufRead,
 {
-    #[inline]
     fn fill_buf(&mut self) -> ::std::io::Result<&[u8]> {
         match self {
             Enum::A(x) => ::std::io::BufRead::fill_buf(x),
@@ -31,7 +30,6 @@ where
         }
     }
 
-    #[inline]
     fn consume(&mut self, amt: usize) {
         match self {
             Enum::A(x) => ::std::io::BufRead::consume(x, amt),
@@ -39,7 +37,6 @@ where
         }
     }
 
-    #[inline]
     fn read_until(&mut self, byte: u8, buf: &mut ::std::vec::Vec<u8>) -> ::std::io::Result<usize> {
         match self {
             Enum::A(x) => ::std::io::BufRead::read_until(x, byte, buf),
@@ -47,7 +44,6 @@ where
         }
     }
 
-    #[inline]
     fn read_line(&mut self, buf: &mut ::std::string::String) -> ::std::io::Result<usize> {
         match self {
             Enum::A(x) => ::std::io::BufRead::read_line(x, buf),

--- a/docs/supported_traits/std/io/read.md
+++ b/docs/supported_traits/std/io/read.md
@@ -23,7 +23,6 @@ where
     A: ::std::io::Read,
     B: ::std::io::Read,
 {
-    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> ::std::io::Result<usize> {
         match self {
             Enum::A(x) => ::std::io::Read::read(x, buf),
@@ -31,7 +30,6 @@ where
         }
     }
 
-    #[inline]
     fn read_to_end(&mut self, buf: &mut ::std::vec::Vec<u8>) -> ::std::io::Result<usize> {
         match self {
             Enum::A(x) => ::std::io::Read::read_to_end(x, buf),
@@ -39,7 +37,6 @@ where
         }
     }
 
-    #[inline]
     fn read_to_string(&mut self, buf: &mut ::std::string::String) -> ::std::io::Result<usize> {
         match self {
             Enum::A(x) => ::std::io::Read::read_to_string(x, buf),
@@ -47,7 +44,6 @@ where
         }
     }
 
-    #[inline]
     fn read_exact(&mut self, buf: &mut [u8]) -> ::std::io::Result<()> {
         match self {
             Enum::A(x) => ::std::io::Read::read_exact(x, buf),

--- a/docs/supported_traits/std/io/seek.md
+++ b/docs/supported_traits/std/io/seek.md
@@ -23,7 +23,6 @@ where
     A: ::std::io::Seek,
     B: ::std::io::Seek,
 {
-    #[inline]
     fn seek(&mut self, pos: ::std::io::SeekFrom) -> ::std::io::Result<u64> {
         match self {
             Enum::A(x) => ::std::io::Seek::seek(x, pos),

--- a/docs/supported_traits/std/io/write.md
+++ b/docs/supported_traits/std/io/write.md
@@ -23,7 +23,6 @@ where
     A: ::std::io::Write,
     B: ::std::io::Write,
 {
-    #[inline]
     fn write(&mut self, buf: &[u8]) -> ::std::io::Result<usize> {
         match self {
             Enum::A(x) => ::std::io::Write::write(x, buf),
@@ -31,7 +30,6 @@ where
         }
     }
 
-    #[inline]
     fn flush(&mut self) -> ::std::io::Result<()> {
         match self {
             Enum::A(x) => ::std::io::Write::flush(x),
@@ -39,7 +37,6 @@ where
         }
     }
 
-    #[inline]
     fn write_all(&mut self, buf: &[u8]) -> ::std::io::Result<()> {
         match self {
             Enum::A(x) => ::std::io::Write::write_all(x, buf),
@@ -47,7 +44,6 @@ where
         }
     }
 
-    #[inline]
     fn write_fmt(&mut self, fmt: ::std::fmt::Arguments<'_>) -> ::std::io::Result<()> {
         match self {
             Enum::A(x) => ::std::io::Write::write_fmt(x, fmt),

--- a/docs/supported_traits/std/iter/DoubleEndedIterator.md
+++ b/docs/supported_traits/std/iter/DoubleEndedIterator.md
@@ -23,7 +23,6 @@ where
     A: ::core::iter::DoubleEndedIterator,
     B: ::core::iter::DoubleEndedIterator<Item = <A as ::core::iter::Iterator>::Item>,
 {
-    #[inline]
     fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
         match self {
             Enum::A(x) => ::core::iter::DoubleEndedIterator::next_back(x),

--- a/docs/supported_traits/std/iter/ExactSizeIterator.md
+++ b/docs/supported_traits/std/iter/ExactSizeIterator.md
@@ -23,7 +23,6 @@ where
     A: ::core::iter::ExactSizeIterator,
     B: ::core::iter::ExactSizeIterator<Item = <A as ::core::iter::Iterator>::Item>,
 {
-    #[inline]
     fn len(&self) -> usize {
         match self {
             Enum::A(x) => ::core::iter::ExactSizeIterator::len(x),

--- a/docs/supported_traits/std/iter/extend.md
+++ b/docs/supported_traits/std/iter/extend.md
@@ -23,7 +23,6 @@ where
     A: ::core::iter::Extend<__A>,
     B: ::core::iter::Extend<__A>,
 {
-    #[inline]
     fn extend<__T: ::core::iter::IntoIterator<Item = __A>>(&mut self, iter: __T) {
         match self {
             Enum::A(x) => ::core::iter::Extend::extend(x, iter),

--- a/docs/supported_traits/std/iter/iterator.md
+++ b/docs/supported_traits/std/iter/iterator.md
@@ -25,7 +25,6 @@ where
 {
     type Item = <A as ::core::iter::Iterator>::Item;
 
-    #[inline]
     fn next(&mut self) -> ::core::option::Option<Self::Item> {
         match self {
             Enum::A(x) => ::core::iter::Iterator::next(x),
@@ -33,7 +32,6 @@ where
         }
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
         match self {
             Enum::A(x) => ::core::iter::Iterator::size_hint(x),
@@ -41,7 +39,6 @@ where
         }
     }
 
-    #[inline]
     fn count(self) -> usize;
         match self {
             Enum::A(x) => ::core::iter::Iterator::count(x),
@@ -49,7 +46,6 @@ where
         }
     }
 
-    #[inline]
     fn last(self) -> ::core::option::Option<Self::Item> {
         match self {
             Enum::A(x) => ::core::iter::Iterator::last(x, fmt),
@@ -57,7 +53,6 @@ where
         }
     }
 
-    #[inline]
     #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
     fn collect<__U: ::core::iter::FromIterator<Self::Item>>(self) -> __U {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,14 +72,12 @@
 //!         __T2: ::core::iter::Iterator<Item = <__T1 as ::core::iter::Iterator>::Item>,
 //!     {
 //!         type Item = <__T1 as ::core::iter::Iterator>::Item;
-//!         #[inline]
 //!         fn next(&mut self) -> ::core::option::Option<Self::Item> {
 //!             match self {
 //!                 __Enum1::__T1(x) => x.next(),
 //!                 __Enum1::__T2(x) => x.next(),
 //!             }
 //!         }
-//!         #[inline]
 //!         fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
 //!             match self {
 //!                 __Enum1::__T1(x) => x.size_hint(),


### PR DESCRIPTION
This isn't actually necessary in most cases and causes an increase in
compile time.