### PR TITLE
Revert "Drop support for old versions of futures and tokio"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: daily
     commit-message:
       prefix: ''
+    ignore:
+      - dependency-name: futures
+      - dependency-name: tokio
     labels: []
   - package-ecosystem: github-actions
     directory: /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
-- Remove `futures` feature. Use `futures03` feature instead.
+- [Remove `futures` feature. Use `futures03` feature instead.](https://github.com/taiki-e/auto_enums/pull/124)
 
 - [Merge `auto_enums_core` and `auto_enums_derive` crates into main `auto_enums` crate.](https://github.com/taiki-e/auto_enums/pull/123)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,7 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
-- [Drop support for old versions of `futures` and `tokio` (`futures01`, `tokio01`, `tokio02`, and `tokio03` features).](https://github.com/taiki-e/auto_enums/pull/125)
-  If support for these traits is needed, use `auto_enums` 0.7 or create your own drive macro ([`derive_utils`](https://github.com/taiki-e/derive_utils) crate can help it).
-
-- [Remove `futures` feature. Use `futures03` feature instead.](https://github.com/taiki-e/auto_enums/pull/124)
+- Remove `futures` feature. Use `futures03` feature instead.
 
 - [Merge `auto_enums_core` and `auto_enums_derive` crates into main `auto_enums` crate.](https://github.com/taiki-e/auto_enums/pull/123)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,20 @@ fmt = []
 
 # https://docs.rs/futures/0.3
 futures03 = []
+# https://docs.rs/futures/0.1
+futures01 = []
 # https://docs.rs/rayon/1
 rayon = []
 # https://docs.rs/serde/1
 serde = []
 # https://docs.rs/tokio/1
 tokio1 = []
+# https://docs.rs/tokio/0.3
+tokio03 = []
+# https://docs.rs/tokio/0.2
+tokio02 = []
+# https://docs.rs/tokio/0.1
+tokio01 = []
 
 # ==============================================================================
 # Unstable features
@@ -88,7 +96,11 @@ trybuild = "1"
 
 # for `#[enum_derive]`
 futures03_crate = { package = "futures", version = "0.3", default-features = false, features = ["std"] }
+futures01_crate = { package = "futures", version = "0.1" }
 tokio1_crate = { package = "tokio", version = "1" }
+tokio03_crate = { package = "tokio", version = "0.3" }
+tokio02_crate = { package = "tokio", version = "0.2" }
+tokio01_crate = { package = "tokio", version = "0.1" }
 rayon_crate = { package = "rayon", version = "1" }
 serde_crate = { package = "serde", version = "1" }
 

--- a/README.md
+++ b/README.md
@@ -141,12 +141,20 @@ enum Foo<A, B> {
   - Enable to use `transpose*` methods.
 - **`futures03`**
   - Enable to use [futures v0.3][futures03] traits.
+- **`futures01`**
+  - Enable to use [futures v0.1][futures01] traits.
 - **`rayon`**
   - Enable to use [rayon] traits.
 - **`serde`**
   - Enable to use [serde] traits.
 - **`tokio1`**
   - Enable to use [tokio v1][tokio1] traits.
+- **`tokio03`**
+  - Enable to use [tokio v0.3][tokio03] traits.
+- **`tokio02`**
+  - Enable to use [tokio v0.2][tokio02] traits.
+- **`tokio01`**
+  - Enable to use [tokio v0.1][tokio01] traits.
 - **`generator_trait`**
   - Enable to use `[std|core]::ops::Generator` trait.
   - Note that this feature is unstable and may cause incompatible changes between patch versions.
@@ -191,6 +199,7 @@ Please be careful if you return another traits with the same name.
 
 [derive_utils]: https://github.com/taiki-e/derive_utils
 [futures-enum]: https://github.com/taiki-e/futures-enum
+[futures01]: https://docs.rs/futures/0.1
 [futures03]: https://docs.rs/futures/0.3
 [io-enum]: https://github.com/taiki-e/io-enum
 [iter-enum]: https://github.com/taiki-e/iter-enum
@@ -199,6 +208,9 @@ Please be careful if you return another traits with the same name.
 [rust-lang/rfcs#294]: https://github.com/rust-lang/rfcs/issues/294
 [rust-lang/rfcs#2414]: https://github.com/rust-lang/rfcs/issues/2414
 [serde]: https://docs.rs/serde/1
+[tokio01]: https://docs.rs/tokio/0.1
+[tokio02]: https://docs.rs/tokio/0.2
+[tokio03]: https://docs.rs/tokio/0.3
 [tokio1]: https://docs.rs/tokio/1
 
 ## Related Projects

--- a/src/derive/external/futures01.rs
+++ b/src/derive/external/futures01.rs
@@ -1,0 +1,59 @@
+pub(crate) mod future {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["futures01::Future"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::futures::future::Future), None, parse_quote! {
+            trait Future {
+                type Item;
+                type Error;
+                #[inline]
+                fn poll(&mut self) -> ::futures::Poll<Self::Item, Self::Error>;
+            }
+        }))
+    }
+}
+
+pub(crate) mod stream {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["futures01::Stream"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::futures::stream::Stream), None, parse_quote! {
+            trait Stream {
+                type Item;
+                type Error;
+                #[inline]
+                fn poll(
+                    &mut self,
+                ) -> ::futures::Poll<::core::option::Option<Self::Item>, Self::Error>;
+            }
+        }))
+    }
+}
+
+pub(crate) mod sink {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["futures01::Sink"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::futures::sink::Sink), None, parse_quote! {
+            trait Sink {
+                type SinkItem;
+                type SinkError;
+                #[inline]
+                fn start_send(
+                    &mut self,
+                    item: Self::SinkItem,
+                ) -> ::futures::StartSend<Self::SinkItem, Self::SinkError>;
+                #[inline]
+                fn poll_complete(&mut self) -> ::futures::Poll<(), Self::SinkError>;
+                #[inline]
+                fn close(&mut self) -> ::futures::Poll<(), Self::SinkError>;
+            }
+        }))
+    }
+}

--- a/src/derive/external/mod.rs
+++ b/src/derive/external/mod.rs
@@ -1,3 +1,6 @@
+// https://docs.rs/futures/0.1
+#[cfg(feature = "futures01")]
+pub(crate) mod futures01;
 // https://docs.rs/futures/0.3
 #[cfg(feature = "futures03")]
 pub(crate) mod futures03;
@@ -7,6 +10,15 @@ pub(crate) mod rayon;
 // https://docs.rs/serde/1
 #[cfg(feature = "serde")]
 pub(crate) mod serde;
+// https://docs.rs/tokio/0.1
+#[cfg(feature = "tokio01")]
+pub(crate) mod tokio01;
+// https://docs.rs/tokio/0.2
+#[cfg(feature = "tokio02")]
+pub(crate) mod tokio02;
+// https://docs.rs/tokio/0.3
+#[cfg(feature = "tokio03")]
+pub(crate) mod tokio03;
 // https://docs.rs/tokio/1
 #[cfg(feature = "tokio1")]
 pub(crate) mod tokio1;

--- a/src/derive/external/tokio01.rs
+++ b/src/derive/external/tokio01.rs
@@ -1,0 +1,48 @@
+pub(crate) mod async_read {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio01::AsyncRead"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
+            trait AsyncRead: ::std::io::Read {
+                unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool;
+                fn poll_read(
+                    &mut self,
+                    buf: &mut [u8],
+                ) -> ::tokio::prelude::Poll<usize, ::std::io::Error>;
+
+                // tokio01 seems does not reexport BufMut.
+                // fn read_buf<__B: BufMut>(
+                //     &mut self,
+                //     buf: &mut __B,
+                // ) -> ::tokio::prelude::Poll<usize, ::std::io::Error>
+                // where
+                //     Self: Sized;
+            }
+        }))
+    }
+}
+
+pub(crate) mod async_write {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio01::AsyncWrite"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
+            trait AsyncWrite: ::std::io::Write {
+                fn poll_write(
+                    &mut self,
+                    buf: &[u8],
+                ) -> ::tokio::prelude::Poll<usize, ::std::io::Error>;
+                fn poll_flush(&mut self) -> ::tokio::prelude::Poll<(), ::std::io::Error>;
+                fn shutdown(&mut self) -> ::tokio::prelude::Poll<(), ::std::io::Error>;
+                // tokio01 seems does not reexport Buf.
+                // fn write_buf<__B: Buf>(&mut self, buf: &mut __B) -> ::tokio::prelude::Poll<usize, ::std::io::Error>
+                // where
+                //     Self: Sized;
+            }
+        }))
+    }
+}

--- a/src/derive/external/tokio02.rs
+++ b/src/derive/external/tokio02.rs
@@ -1,0 +1,103 @@
+pub(crate) mod async_buf_read {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio02::AsyncBufRead"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncBufRead), None, parse_quote! {
+            trait AsyncBufRead {
+                fn poll_fill_buf<'__a>(
+                    self: ::core::pin::Pin<&'__a mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>>;
+                fn consume(self: ::core::pin::Pin<&mut Self>, amt: usize);
+            }
+        }))
+    }
+}
+
+pub(crate) mod async_read {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio02::AsyncRead"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
+            trait AsyncRead {
+                unsafe fn prepare_uninitialized_buffer(
+                    &self,
+                    buf: &mut [::core::mem::MaybeUninit<u8>],
+                ) -> bool;
+                fn poll_read(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                    buf: &mut [u8],
+                ) -> ::core::task::Poll<::std::io::Result<usize>>;
+                // tokio02 seems does not reexport BufMut.
+                // fn poll_read_buf<__B: BufMut>(
+                //     self: ::core::pin::Pin<&mut Self>,
+                //     cx: &mut ::core::task::Context<'_>,
+                //     buf: &mut __B,
+                // ) -> ::core::task::Poll<::std::io::Result<usize>>
+                // where
+                //     Self: Sized;
+            }
+        }))
+    }
+}
+
+pub(crate) mod async_seek {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio02::AsyncSeek"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncSeek), None, parse_quote! {
+            trait AsyncSeek {
+                fn start_seek(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                    pos: ::std::io::SeekFrom,
+                ) -> ::core::task::Poll<::std::io::Result<()>>;
+                fn poll_complete(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<u64>>;
+            }
+        }))
+    }
+}
+
+pub(crate) mod async_write {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio02::AsyncWrite"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
+            trait AsyncWrite {
+                fn poll_write(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                    buf: &[u8],
+                ) -> ::core::task::Poll<::std::io::Result<usize>>;
+                fn poll_flush(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<()>>;
+                fn poll_shutdown(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<()>>;
+                // tokio02 seems does not reexport Buf.
+                // fn poll_write_buf<__B: Buf>(
+                //     self: ::core::pin::Pin<&mut Self>,
+                //     cx: &mut ::core::task::Context<'_>,
+                //     buf: &mut __B,
+                // ) -> ::core::task::Poll<::std::io::Result<usize>>
+                // where
+                //     Self: Sized;
+            }
+        }))
+    }
+}

--- a/src/derive/external/tokio03.rs
+++ b/src/derive/external/tokio03.rs
@@ -1,0 +1,82 @@
+pub(crate) mod async_buf_read {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio03::AsyncBufRead"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncBufRead), None, parse_quote! {
+            trait AsyncBufRead {
+                fn poll_fill_buf<'__a>(
+                    self: ::core::pin::Pin<&'__a mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>>;
+                fn consume(self: ::core::pin::Pin<&mut Self>, amt: usize);
+            }
+        }))
+    }
+}
+
+pub(crate) mod async_read {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio03::AsyncRead"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
+            trait AsyncRead {
+                fn poll_read(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                    buf: &mut ::tokio::io::ReadBuf<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<()>>;
+            }
+        }))
+    }
+}
+
+pub(crate) mod async_seek {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio03::AsyncSeek"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncSeek), None, parse_quote! {
+            trait AsyncSeek {
+                fn start_seek(
+                    self: ::core::pin::Pin<&mut Self>,
+                    pos: ::std::io::SeekFrom,
+                ) -> ::std::io::Result<()>;
+                fn poll_complete(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<u64>>;
+            }
+        }))
+    }
+}
+
+pub(crate) mod async_write {
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["tokio03::AsyncWrite"];
+
+    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
+            trait AsyncWrite {
+                fn poll_write(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                    buf: &[u8],
+                ) -> ::core::task::Poll<::std::io::Result<usize>>;
+                fn poll_flush(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<()>>;
+                fn poll_shutdown(
+                    self: ::core::pin::Pin<&mut Self>,
+                    cx: &mut ::core::task::Context<'_>,
+                ) -> ::core::task::Poll<::std::io::Result<()>>;
+            }
+        }))
+    }
+}

--- a/src/enum_derive.rs
+++ b/src/enum_derive.rs
@@ -100,6 +100,13 @@ fn get_derive(s: &str) -> Option<DeriveFn> {
         external::futures03::async_seek,
         #[cfg(feature = "futures03")]
         external::futures03::async_buf_read,
+        // futures01
+        #[cfg(feature = "futures01")]
+        external::futures01::future,
+        #[cfg(feature = "futures01")]
+        external::futures01::stream,
+        #[cfg(feature = "futures01")]
+        external::futures01::sink,
         // rayon
         #[cfg(feature = "rayon")]
         external::rayon::par_iter,
@@ -119,6 +126,29 @@ fn get_derive(s: &str) -> Option<DeriveFn> {
         external::tokio1::async_seek,
         #[cfg(feature = "tokio1")]
         external::tokio1::async_buf_read,
+        // tokio03
+        #[cfg(feature = "tokio03")]
+        external::tokio03::async_read,
+        #[cfg(feature = "tokio03")]
+        external::tokio03::async_write,
+        #[cfg(feature = "tokio03")]
+        external::tokio03::async_seek,
+        #[cfg(feature = "tokio03")]
+        external::tokio03::async_buf_read,
+        // tokio02
+        #[cfg(feature = "tokio02")]
+        external::tokio02::async_read,
+        #[cfg(feature = "tokio02")]
+        external::tokio02::async_write,
+        #[cfg(feature = "tokio02")]
+        external::tokio02::async_seek,
+        #[cfg(feature = "tokio02")]
+        external::tokio02::async_buf_read,
+        // tokio01
+        #[cfg(feature = "tokio01")]
+        external::tokio01::async_read,
+        #[cfg(feature = "tokio01")]
+        external::tokio01::async_write,
     }
 
     None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,6 +690,12 @@
 //!
 //! *See also [futures-enum] crate.*
 //!
+//! ### [futures v0.1][futures01] *(requires `"futures01"` crate feature)*
+//!
+//! * [`futures01::Future`](https://docs.rs/futures/0.1/futures/future/trait.Future.html)
+//! * [`futures01::Stream`](https://docs.rs/futures/0.1/futures/stream/trait.Stream.html)
+//! * [`futures01::Sink`](https://docs.rs/futures/0.1/futures/sink/trait.Sink.html)
+//!
 //! ### [rayon] *(requires `"rayon"` crate feature)*
 //!
 //! * [`rayon::ParallelIterator`](https://docs.rs/rayon/1/rayon/iter/trait.ParallelIterator.html) - [generated code](https://github.com/taiki-e/auto_enums/blob/HEAD/docs/supported_traits/external/rayon/ParallelIterator.md)
@@ -706,6 +712,25 @@
 //! * [`tokio1::AsyncWrite`](https://docs.rs/tokio/1/tokio/io/trait.AsyncWrite.html)
 //! * [`tokio1::AsyncSeek`](https://docs.rs/tokio/1/tokio/io/trait.AsyncSeek.html)
 //! * [`tokio1::AsyncBufRead`](https://docs.rs/tokio/1/tokio/io/trait.AsyncBufRead.html)
+//!
+//! ### [tokio v0.3][tokio03] *(requires `"tokio03"` crate feature)*
+//!
+//! * [`tokio03::AsyncRead`](https://docs.rs/tokio/0.3/tokio/io/trait.AsyncRead.html)
+//! * [`tokio03::AsyncWrite`](https://docs.rs/tokio/0.3/tokio/io/trait.AsyncWrite.html)
+//! * [`tokio03::AsyncSeek`](https://docs.rs/tokio/0.3/tokio/io/trait.AsyncSeek.html)
+//! * [`tokio03::AsyncBufRead`](https://docs.rs/tokio/0.3/tokio/io/trait.AsyncBufRead.html)
+//!
+//! ### [tokio v0.2][tokio02] *(requires `"tokio02"` crate feature)*
+//!
+//! * [`tokio02::AsyncRead`](https://docs.rs/tokio/0.2/tokio/io/trait.AsyncRead.html)
+//! * [`tokio02::AsyncWrite`](https://docs.rs/tokio/0.2/tokio/io/trait.AsyncWrite.html)
+//! * [`tokio02::AsyncSeek`](https://docs.rs/tokio/0.2/tokio/io/trait.AsyncSeek.html)
+//! * [`tokio02::AsyncBufRead`](https://docs.rs/tokio/0.2/tokio/io/trait.AsyncBufRead.html)
+//!
+//! ### [tokio v0.1][tokio01] *(requires `"tokio01"` crate feature)*
+//!
+//! * [`tokio01::AsyncRead`](https://docs.rs/tokio/0.1/tokio/io/trait.AsyncRead.html)
+//! * [`tokio01::AsyncWrite`](https://docs.rs/tokio/0.1/tokio/io/trait.AsyncWrite.html)
 //!
 //! ## Inherent methods
 //!
@@ -750,12 +775,20 @@
 //!   * Enable to use `transpose*` methods.
 //! * **`futures03`**
 //!   * Enable to use [futures v0.3][futures03] traits.
+//! * **`futures01`**
+//!   * Enable to use [futures v0.1][futures01] traits.
 //! * **`rayon`**
 //!   * Enable to use [rayon] traits.
 //! * **`serde`**
 //!   * Enable to use [serde] traits.
 //! * **`tokio1`**
 //!   * Enable to use [tokio v1][tokio1] traits.
+//! * **`tokio03`**
+//!   * Enable to use [tokio v0.3][tokio03] traits.
+//! * **`tokio02`**
+//!   * Enable to use [tokio v0.2][tokio02] traits.
+//! * **`tokio01`**
+//!   * Enable to use [tokio v0.1][tokio01] traits.
 //! * **`generator_trait`**
 //!   * Enable to use `[std|core]::ops::Generator` trait.
 //!   * Note that this feature is unstable and may cause incompatible changes between patch versions.
@@ -805,12 +838,16 @@
 //!
 //! [derive_utils]: https://github.com/taiki-e/derive_utils
 //! [futures-enum]: https://github.com/taiki-e/futures-enum
+//! [futures01]: https://docs.rs/futures/0.1
 //! [futures03]: https://docs.rs/futures/0.3
 //! [io-enum]: https://github.com/taiki-e/io-enum
 //! [iter-enum]: https://github.com/taiki-e/iter-enum
 //! [proc-macro-derive]: https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros
 //! [rayon]: https://docs.rs/rayon/1
 //! [serde]: https://docs.rs/serde/1
+//! [tokio01]: https://docs.rs/tokio/0.1
+//! [tokio02]: https://docs.rs/tokio/0.2
+//! [tokio03]: https://docs.rs/tokio/0.3
 //! [tokio1]: https://docs.rs/tokio/1
 
 #![doc(test(

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -2,9 +2,13 @@
     feature = "std",
     feature = "type_analysis",
     feature = "transpose_methods",
+    feature = "futures01",
     feature = "futures03",
     feature = "rayon",
     feature = "serde",
+    feature = "tokio01",
+    feature = "tokio02",
+    feature = "tokio03",
     feature = "tokio1",
 ))]
 #![warn(rust_2018_idioms, single_use_lifetimes)]

--- a/tests/ui/external/futures01.rs
+++ b/tests/ui/external/futures01.rs
@@ -1,0 +1,11 @@
+extern crate futures01_crate as futures;
+
+use auto_enums::enum_derive;
+
+#[enum_derive(futures01::Future, futures01::Sink, futures01::Stream)]
+enum Futures01<A, B> {
+    A(A),
+    B(B),
+}
+
+fn main() {}

--- a/tests/ui/external/tokio01.rs
+++ b/tests/ui/external/tokio01.rs
@@ -1,0 +1,11 @@
+extern crate tokio01_crate as tokio;
+
+use auto_enums::enum_derive;
+
+#[enum_derive(tokio01::AsyncRead, tokio01::AsyncWrite, Read, Write)]
+enum Tokio01<A, B> {
+    A(A),
+    B(B),
+}
+
+fn main() {}

--- a/tests/ui/external/tokio02.rs
+++ b/tests/ui/external/tokio02.rs
@@ -1,0 +1,11 @@
+extern crate tokio02_crate as tokio;
+
+use auto_enums::enum_derive;
+
+#[enum_derive(tokio02::AsyncRead, tokio02::AsyncWrite, tokio02::AsyncSeek, tokio02::AsyncBufRead)]
+enum Tokio02<A, B> {
+    A(A),
+    B(B),
+}
+
+fn main() {}

--- a/tests/ui/external/tokio03.rs
+++ b/tests/ui/external/tokio03.rs
@@ -1,0 +1,11 @@
+extern crate tokio03_crate as tokio;
+
+use auto_enums::enum_derive;
+
+#[enum_derive(tokio03::AsyncRead, tokio03::AsyncWrite, tokio03::AsyncSeek, tokio03::AsyncBufRead)]
+enum Tokio03<A, B> {
+    A(A),
+    B(B),
+}
+
+fn main() {}


### PR DESCRIPTION
This reverts commit 12a7e05721712cdda07f6605d3e6322ed110c742.