### PR TITLE
Forbid custom Unpin/Drop impl if trait has Pin<&mut self> receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ trusted_len = []
 
 # Note: futures, tokio, serde, and rayon are public dependencies.
 [dependencies]
-derive_utils = { version = "0.11" }
+derive_utils = { version = "0.12" }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1.0.56", features = ["full", "visit-mut"] }

--- a/src/derive/core/convert.rs
+++ b/src/derive/core/convert.rs
@@ -3,7 +3,7 @@ pub(crate) mod as_ref {
 
     pub(crate) const NAME: &[&str] = &["AsRef"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::core::convert::AsRef), None, parse_quote! {
             trait AsRef<__T: ?Sized> {
                 #[inline]
@@ -18,7 +18,7 @@ pub(crate) mod as_mut {
 
     pub(crate) const NAME: &[&str] = &["AsMut"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::core::convert::AsMut), None, parse_quote! {
             trait AsMut<__T: ?Sized> {
                 #[inline]

--- a/src/derive/core/fmt.rs
+++ b/src/derive/core/fmt.rs
@@ -5,7 +5,7 @@ macro_rules! derive_fmt {
 
             pub(crate) const NAME: &[&str] = &[$($name),*];
 
-            pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+            pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
                 Ok(derive_trait(data, parse_quote!(::core::fmt::$Trait), None, parse_quote! {
                     trait $Trait {
                         #[inline]
@@ -40,7 +40,7 @@ pub(crate) mod write {
 
     pub(crate) const NAME: &[&str] = &["fmt::Write"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::core::fmt::Write), None, parse_quote! {
             trait Write {
                 #[inline]

--- a/src/derive/core/future.rs
+++ b/src/derive/core/future.rs
@@ -2,7 +2,8 @@ use crate::derive::*;
 
 pub(crate) const NAME: &[&str] = &["Future"];
 
-pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+    cx.needs_pin_projection();
     Ok(derive_trait(data, parse_quote!(::core::future::Future), None, parse_quote! {
         trait Future {
             type Output;

--- a/src/derive/core/iter.rs
+++ b/src/derive/core/iter.rs
@@ -3,7 +3,7 @@ pub(crate) mod iterator {
 
     pub(crate) const NAME: &[&str] = &["Iterator"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         // TODO: When `try_trait` stabilized, add `try_fold` and remove `fold`, `find` etc. conditionally.
 
         // It is equally efficient if `try_fold` can be used.
@@ -47,7 +47,7 @@ pub(crate) mod double_ended_iterator {
 
     pub(crate) const NAME: &[&str] = &["DoubleEndedIterator"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         // TODO: When `try_trait` stabilized, add `try_rfold` and remove `rfold` and `rfind` conditionally.
 
         // It is equally efficient if `try_rfold` can be used.
@@ -82,7 +82,7 @@ pub(crate) mod exact_size_iterator {
 
     pub(crate) const NAME: &[&str] = &["ExactSizeIterator"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         // TODO: When `exact_size_is_empty` stabilized, add `is_empty` conditionally.
 
         Ok(derive_trait(
@@ -104,7 +104,7 @@ pub(crate) mod fused_iterator {
 
     pub(crate) const NAME: &[&str] = &["FusedIterator"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(
             data,
             parse_quote!(::core::iter::FusedIterator),
@@ -122,7 +122,7 @@ pub(crate) mod trusted_len {
 
     pub(crate) const NAME: &[&str] = &["TrustedLen"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(
             data,
             parse_quote!(::core::iter::TrustedLen),
@@ -139,7 +139,7 @@ pub(crate) mod extend {
 
     pub(crate) const NAME: &[&str] = &["Extend"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::core::iter::Extend), None, parse_quote! {
             trait Extend<__A> {
                 #[inline]

--- a/src/derive/core/ops.rs
+++ b/src/derive/core/ops.rs
@@ -4,7 +4,7 @@ pub(crate) mod deref {
 
     pub(crate) const NAME: &[&str] = &["Deref"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::core::ops::Deref), None, parse_quote! {
             trait Deref {
                 type Target;
@@ -21,7 +21,7 @@ pub(crate) mod deref_mut {
 
     pub(crate) const NAME: &[&str] = &["DerefMut"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(
             data,
             parse_quote!(::core::ops::DerefMut),
@@ -42,7 +42,7 @@ pub(crate) mod index {
 
     pub(crate) const NAME: &[&str] = &["Index"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::core::ops::Index), None, parse_quote! {
             trait Index<__Idx> {
                 type Output;
@@ -59,7 +59,7 @@ pub(crate) mod index_mut {
 
     pub(crate) const NAME: &[&str] = &["IndexMut"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(
             data,
             parse_quote!(::core::ops::IndexMut),
@@ -80,7 +80,7 @@ pub(crate) mod range_bounds {
 
     pub(crate) const NAME: &[&str] = &["RangeBounds"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::core::ops::RangeBounds), None, parse_quote! {
             trait RangeBounds<__T: ?Sized> {
                 #[inline]
@@ -98,7 +98,8 @@ pub(crate) mod generator {
 
     pub(crate) const NAME: &[&str] = &["Generator"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::core::ops::Generator), None, parse_quote! {
             trait Generator<R> {
                 type Yield;
@@ -122,7 +123,7 @@ pub(crate) mod fn_ {
 
     pub(crate) const NAME: &[&str] = &["Fn"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         let trait_path = quote!(::core::ops::Fn);
         let trait_ = quote!(#trait_path(__T) -> __U);
         let fst = data.field_types().next();
@@ -155,7 +156,7 @@ pub(crate) mod fn_mut {
 
     pub(crate) const NAME: &[&str] = &["FnMut"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         let trait_path = quote!(::core::ops::FnMut);
         let trait_ = quote!(#trait_path(__T) -> __U);
         let fst = data.field_types().next();
@@ -188,7 +189,7 @@ pub(crate) mod fn_once {
 
     pub(crate) const NAME: &[&str] = &["FnOnce"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         let trait_path = quote!(::core::ops::FnOnce);
         let trait_ = quote!(#trait_path(__T) -> __U);
         let fst = data.field_types().next();

--- a/src/derive/external/futures01.rs
+++ b/src/derive/external/futures01.rs
@@ -3,7 +3,7 @@ pub(crate) mod future {
 
     pub(crate) const NAME: &[&str] = &["futures01::Future"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::futures::future::Future), None, parse_quote! {
             trait Future {
                 type Item;
@@ -20,7 +20,7 @@ pub(crate) mod stream {
 
     pub(crate) const NAME: &[&str] = &["futures01::Stream"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::futures::stream::Stream), None, parse_quote! {
             trait Stream {
                 type Item;
@@ -39,7 +39,7 @@ pub(crate) mod sink {
 
     pub(crate) const NAME: &[&str] = &["futures01::Sink"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::futures::sink::Sink), None, parse_quote! {
             trait Sink {
                 type SinkItem;

--- a/src/derive/external/futures03.rs
+++ b/src/derive/external/futures03.rs
@@ -1,159 +1,354 @@
 pub(crate) mod async_buf_read {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["futures03::AsyncBufRead"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::futures::io::AsyncBufRead), None, parse_quote! {
-            trait AsyncBufRead {
-                #[inline]
-                fn poll_fill_buf<'__a>(
-                    self: ::core::pin::Pin<&'__a mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>>;
-                #[inline]
-                fn consume(self: ::core::pin::Pin<&mut Self>, amt: usize);
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::futures::io::AsyncBufRead);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncBufRead {}
+        })
+        .build_impl();
+
+        let poll_fill_buf = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_fill_buf(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_fill_buf(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<&[u8]>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_fill_buf,)* }
+                }
             }
-        }))
+        });
+
+        let consume = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::consume(#pin::new_unchecked(x), amt)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn consume(self: #pin<&mut Self>, amt: usize) {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#consume,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_read {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["futures03::AsyncRead"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::futures::io::AsyncRead), None, parse_quote! {
-            trait AsyncRead {
-                #[inline]
-                fn poll_read(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    buf: &mut [u8],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                #[inline]
-                fn poll_read_vectored(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    bufs: &mut [::std::io::IoSliceMut<'_>],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::futures::io::AsyncRead);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncRead {}
+        })
+        .build_impl();
+
+        let poll_read = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_read(#pin::new_unchecked(x), cx, buf)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_read(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                buf: &mut [u8],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_read,)* }
+                }
             }
-        }))
+        });
+
+        let poll_read_vectored = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_read_vectored(#pin::new_unchecked(x), cx, bufs)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_read_vectored(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                bufs: &mut [::std::io::IoSliceMut<'_>],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_read_vectored,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_seek {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["futures03::AsyncSeek"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::futures::io::AsyncSeek), None, parse_quote! {
-            trait AsyncSeek {
-                #[inline]
-                fn poll_seek(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    pos: ::std::io::SeekFrom,
-                ) -> ::core::task::Poll<::std::io::Result<u64>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::futures::io::AsyncSeek);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncSeek {}
+        })
+        .build_impl();
+
+        let poll_seek = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_seek(#pin::new_unchecked(x), cx, pos)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_seek(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                pos: ::std::io::SeekFrom,
+            ) -> ::core::task::Poll<::std::io::Result<u64>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_seek,)* }
+                }
             }
-        }))
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_write {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["futures03::AsyncWrite"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::futures::io::AsyncWrite), None, parse_quote! {
-            trait AsyncWrite {
-                #[inline]
-                fn poll_write(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    buf: &[u8],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                #[inline]
-                fn poll_write_vectored(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    bufs: &[::std::io::IoSlice<'_>],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                #[inline]
-                fn poll_flush(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
-                #[inline]
-                fn poll_close(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::futures::io::AsyncWrite);
+        let mut impl_ = EnumImpl::from_trait(
+            data,
+            parse_quote!(::futures::io::AsyncWrite),
+            None,
+            parse_quote! {
+                trait AsyncWrite {}
+            },
+        )
+        .build_impl();
+
+        let poll_write = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_write(#pin::new_unchecked(x), cx, buf)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_write(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                buf: &[u8],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_write,)* }
+                }
             }
-        }))
+        });
+
+        let poll_write_vectored = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_write_vectored(#pin::new_unchecked(x), cx, bufs)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_write_vectored(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                bufs: &[::std::io::IoSlice<'_>],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_write_vectored,)* }
+                }
+            }
+        });
+
+        let poll_flush = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_flush(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_flush(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_flush,)* }
+                }
+            }
+        });
+
+        let poll_close = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_close(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_close(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_close,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod sink {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["futures03::Sink"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::futures::sink::Sink), None, parse_quote! {
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::futures::sink::Sink);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
             trait Sink<Item> {
                 type Error;
-                #[inline]
-                fn poll_ready(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::core::result::Result<(), Self::Error>>;
-                #[inline]
-                fn start_send(
-                    self: ::core::pin::Pin<&mut Self>,
-                    item: Item,
-                ) -> ::core::result::Result<(), Self::Error>;
-                #[inline]
-                fn poll_flush(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::core::result::Result<(), Self::Error>>;
-                #[inline]
-                fn poll_close(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::core::result::Result<(), Self::Error>>;
             }
-        }))
+        })
+        .build_impl();
+
+        let poll_ready = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_ready(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_ready(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::core::result::Result<(), Self::Error>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_ready,)* }
+                }
+            }
+        });
+
+        let start_send = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::start_send(#pin::new_unchecked(x), item)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn start_send(
+                self: #pin<&mut Self>,
+                item: Item,
+            ) -> ::core::result::Result<(), Self::Error> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#start_send,)* }
+                }
+            }
+        });
+
+        let poll_flush = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_flush(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_flush(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::core::result::Result<(), Self::Error>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_flush,)* }
+                }
+            }
+        });
+
+        let poll_close = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_close(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_close(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::core::result::Result<(), Self::Error>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_close,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod stream {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["futures03::Stream"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::futures::stream::Stream), None, parse_quote! {
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::futures::stream::Stream);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
             trait Stream {
                 type Item;
                 #[inline]
-                fn poll_next(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::core::option::Option<Self::Item>>;
-                #[inline]
                 fn size_hint(&self) -> (usize, ::core::option::Option<usize>);
             }
-        }))
+        })
+        .build_impl();
+
+        let poll_next = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_next(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            #[inline]
+            fn poll_next(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::core::option::Option<Self::Item>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_next,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }

--- a/src/derive/external/futures03.rs
+++ b/src/derive/external/futures03.rs
@@ -3,7 +3,8 @@ pub(crate) mod async_buf_read {
 
     pub(crate) const NAME: &[&str] = &["futures03::AsyncBufRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::futures::io::AsyncBufRead), None, parse_quote! {
             trait AsyncBufRead {
                 #[inline]
@@ -23,7 +24,8 @@ pub(crate) mod async_read {
 
     pub(crate) const NAME: &[&str] = &["futures03::AsyncRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::futures::io::AsyncRead), None, parse_quote! {
             trait AsyncRead {
                 #[inline]
@@ -48,7 +50,8 @@ pub(crate) mod async_seek {
 
     pub(crate) const NAME: &[&str] = &["futures03::AsyncSeek"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::futures::io::AsyncSeek), None, parse_quote! {
             trait AsyncSeek {
                 #[inline]
@@ -67,7 +70,8 @@ pub(crate) mod async_write {
 
     pub(crate) const NAME: &[&str] = &["futures03::AsyncWrite"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::futures::io::AsyncWrite), None, parse_quote! {
             trait AsyncWrite {
                 #[inline]
@@ -102,7 +106,8 @@ pub(crate) mod sink {
 
     pub(crate) const NAME: &[&str] = &["futures03::Sink"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::futures::sink::Sink), None, parse_quote! {
             trait Sink<Item> {
                 type Error;
@@ -136,7 +141,8 @@ pub(crate) mod stream {
 
     pub(crate) const NAME: &[&str] = &["futures03::Stream"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::futures::stream::Stream), None, parse_quote! {
             trait Stream {
                 type Item;

--- a/src/derive/external/rayon.rs
+++ b/src/derive/external/rayon.rs
@@ -3,7 +3,7 @@ pub(crate) mod par_iter {
 
     pub(crate) const NAME: &[&str] = &["rayon::ParallelIterator"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::rayon::iter::ParallelIterator), None, parse_quote! {
             trait ParallelIterator {
                 type Item;
@@ -23,7 +23,7 @@ pub(crate) mod indexed_par_iter {
 
     pub(crate) const NAME: &[&str] = &["rayon::IndexedParallelIterator"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(
             data,
             parse_quote!(::rayon::iter::IndexedParallelIterator),
@@ -51,7 +51,7 @@ pub(crate) mod par_extend {
 
     pub(crate) const NAME: &[&str] = &["rayon::ParallelExtend"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::rayon::iter::ParallelExtend), None, parse_quote! {
             trait ParallelExtend<__T: Send> {
                 #[inline]

--- a/src/derive/external/serde.rs
+++ b/src/derive/external/serde.rs
@@ -3,7 +3,7 @@ pub(crate) mod serialize {
 
     pub(crate) const NAME: &[&str] = &["serde::Serialize"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::serde::ser::Serialize), None, parse_quote! {
             trait Serialize {
                 #[inline]

--- a/src/derive/external/tokio01.rs
+++ b/src/derive/external/tokio01.rs
@@ -3,7 +3,7 @@ pub(crate) mod async_read {
 
     pub(crate) const NAME: &[&str] = &["tokio01::AsyncRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
             trait AsyncRead: ::std::io::Read {
                 unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool;
@@ -29,7 +29,7 @@ pub(crate) mod async_write {
 
     pub(crate) const NAME: &[&str] = &["tokio01::AsyncWrite"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
             trait AsyncWrite: ::std::io::Write {
                 fn poll_write(

--- a/src/derive/external/tokio02.rs
+++ b/src/derive/external/tokio02.rs
@@ -1,107 +1,222 @@
 pub(crate) mod async_buf_read {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio02::AsyncBufRead"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncBufRead), None, parse_quote! {
-            trait AsyncBufRead {
-                fn poll_fill_buf<'__a>(
-                    self: ::core::pin::Pin<&'__a mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>>;
-                fn consume(self: ::core::pin::Pin<&mut Self>, amt: usize);
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncBufRead);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncBufRead {}
+        })
+        .build_impl();
+
+        let poll_fill_buf = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_fill_buf(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_fill_buf(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<&[u8]>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_fill_buf,)* }
+                }
             }
-        }))
+        });
+
+        let consume = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::consume(#pin::new_unchecked(x), amt)));
+        impl_.items.push(parse_quote! {
+            fn consume(self: #pin<&mut Self>, amt: usize) {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#consume,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_read {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio02::AsyncRead"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncRead);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
             trait AsyncRead {
                 unsafe fn prepare_uninitialized_buffer(
                     &self,
                     buf: &mut [::core::mem::MaybeUninit<u8>],
                 ) -> bool;
-                fn poll_read(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    buf: &mut [u8],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                // tokio02 seems does not reexport BufMut.
-                // fn poll_read_buf<__B: BufMut>(
-                //     self: ::core::pin::Pin<&mut Self>,
-                //     cx: &mut ::core::task::Context<'_>,
-                //     buf: &mut __B,
-                // ) -> ::core::task::Poll<::std::io::Result<usize>>
-                // where
-                //     Self: Sized;
             }
-        }))
+        })
+        .build_impl();
+
+        let poll_read = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_read(#pin::new_unchecked(x), cx, buf)));
+        impl_.items.push(parse_quote! {
+            fn poll_read(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                buf: &mut [u8],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_read,)* }
+                }
+            }
+        });
+
+        // tokio02 seems does not reexport BufMut.
+        // fn poll_read_buf<__B: BufMut>(
+        //     self: ::core::pin::Pin<&mut Self>,
+        //     cx: &mut ::core::task::Context<'_>,
+        //     buf: &mut __B,
+        // ) -> ::core::task::Poll<::std::io::Result<usize>>
+        // where
+        //     Self: Sized;
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_seek {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio02::AsyncSeek"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncSeek), None, parse_quote! {
-            trait AsyncSeek {
-                fn start_seek(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    pos: ::std::io::SeekFrom,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
-                fn poll_complete(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<u64>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncSeek);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncSeek {}
+        })
+        .build_impl();
+
+        let start_seek = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::start_seek(#pin::new_unchecked(x), cx, pos)));
+        impl_.items.push(parse_quote! {
+            fn start_seek(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                pos: ::std::io::SeekFrom,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#start_seek,)* }
+                }
             }
-        }))
+        });
+
+        let poll_complete = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_complete(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_complete(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<u64>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_complete,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_write {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio02::AsyncWrite"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
-            trait AsyncWrite {
-                fn poll_write(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    buf: &[u8],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                fn poll_flush(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
-                fn poll_shutdown(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
-                // tokio02 seems does not reexport Buf.
-                // fn poll_write_buf<__B: Buf>(
-                //     self: ::core::pin::Pin<&mut Self>,
-                //     cx: &mut ::core::task::Context<'_>,
-                //     buf: &mut __B,
-                // ) -> ::core::task::Poll<::std::io::Result<usize>>
-                // where
-                //     Self: Sized;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncWrite);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncWrite {}
+        })
+        .build_impl();
+
+        let poll_write = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_write(#pin::new_unchecked(x), cx, buf)));
+        impl_.items.push(parse_quote! {
+            fn poll_write(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                buf: &[u8],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_write,)* }
+                }
             }
-        }))
+        });
+
+        let poll_flush = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_flush(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_flush(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_flush,)* }
+                }
+            }
+        });
+
+        let poll_shutdown = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_shutdown(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_shutdown(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_shutdown,)* }
+                }
+            }
+        });
+
+        // tokio02 seems does not reexport Buf.
+        // fn poll_write_buf<__B: Buf>(
+        //     self: ::core::pin::Pin<&mut Self>,
+        //     cx: &mut ::core::task::Context<'_>,
+        //     buf: &mut __B,
+        // ) -> ::core::task::Poll<::std::io::Result<usize>>
+        // where
+        //     Self: Sized;
+
+        Ok(impl_.into_token_stream())
     }
 }

--- a/src/derive/external/tokio02.rs
+++ b/src/derive/external/tokio02.rs
@@ -3,7 +3,8 @@ pub(crate) mod async_buf_read {
 
     pub(crate) const NAME: &[&str] = &["tokio02::AsyncBufRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncBufRead), None, parse_quote! {
             trait AsyncBufRead {
                 fn poll_fill_buf<'__a>(
@@ -21,7 +22,8 @@ pub(crate) mod async_read {
 
     pub(crate) const NAME: &[&str] = &["tokio02::AsyncRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
             trait AsyncRead {
                 unsafe fn prepare_uninitialized_buffer(
@@ -51,7 +53,8 @@ pub(crate) mod async_seek {
 
     pub(crate) const NAME: &[&str] = &["tokio02::AsyncSeek"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncSeek), None, parse_quote! {
             trait AsyncSeek {
                 fn start_seek(
@@ -73,7 +76,8 @@ pub(crate) mod async_write {
 
     pub(crate) const NAME: &[&str] = &["tokio02::AsyncWrite"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
             trait AsyncWrite {
                 fn poll_write(

--- a/src/derive/external/tokio03.rs
+++ b/src/derive/external/tokio03.rs
@@ -1,86 +1,198 @@
 pub(crate) mod async_buf_read {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio03::AsyncBufRead"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncBufRead), None, parse_quote! {
-            trait AsyncBufRead {
-                fn poll_fill_buf<'__a>(
-                    self: ::core::pin::Pin<&'__a mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>>;
-                fn consume(self: ::core::pin::Pin<&mut Self>, amt: usize);
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncBufRead);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncBufRead {}
+        })
+        .build_impl();
+
+        let poll_fill_buf = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_fill_buf(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_fill_buf(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<&[u8]>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_fill_buf,)* }
+                }
             }
-        }))
+        });
+
+        let consume = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::consume(#pin::new_unchecked(x), amt)));
+        impl_.items.push(parse_quote! {
+            fn consume(self: #pin<&mut Self>, amt: usize) {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#consume,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_read {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio03::AsyncRead"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
-            trait AsyncRead {
-                fn poll_read(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    buf: &mut ::tokio::io::ReadBuf<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncRead);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncRead {}
+        })
+        .build_impl();
+
+        let poll_read = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_read(#pin::new_unchecked(x), cx, buf)));
+        impl_.items.push(parse_quote! {
+            fn poll_read(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                buf: &mut ::tokio::io::ReadBuf<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_read,)* }
+                }
             }
-        }))
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_seek {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio03::AsyncSeek"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncSeek), None, parse_quote! {
-            trait AsyncSeek {
-                fn start_seek(
-                    self: ::core::pin::Pin<&mut Self>,
-                    pos: ::std::io::SeekFrom,
-                ) -> ::std::io::Result<()>;
-                fn poll_complete(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<u64>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncSeek);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncSeek {}
+        })
+        .build_impl();
+
+        let start_seek = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::start_seek(#pin::new_unchecked(x), pos)));
+        impl_.items.push(parse_quote! {
+            fn start_seek(
+                self: #pin<&mut Self>,
+                pos: ::std::io::SeekFrom,
+            ) -> ::std::io::Result<()> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#start_seek,)* }
+                }
             }
-        }))
+        });
+
+        let poll_complete = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_complete(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_complete(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<u64>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_complete,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_write {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio03::AsyncWrite"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
-            trait AsyncWrite {
-                fn poll_write(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    buf: &[u8],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                fn poll_flush(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
-                fn poll_shutdown(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncWrite);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncWrite {}
+        })
+        .build_impl();
+
+        let poll_write = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_write(#pin::new_unchecked(x), cx, buf)));
+        impl_.items.push(parse_quote! {
+            fn poll_write(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                buf: &[u8],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_write,)* }
+                }
             }
-        }))
+        });
+
+        let poll_flush = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_flush(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_flush(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_flush,)* }
+                }
+            }
+        });
+
+        let poll_shutdown = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_shutdown(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_shutdown(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_shutdown,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }

--- a/src/derive/external/tokio03.rs
+++ b/src/derive/external/tokio03.rs
@@ -3,7 +3,8 @@ pub(crate) mod async_buf_read {
 
     pub(crate) const NAME: &[&str] = &["tokio03::AsyncBufRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncBufRead), None, parse_quote! {
             trait AsyncBufRead {
                 fn poll_fill_buf<'__a>(
@@ -21,7 +22,8 @@ pub(crate) mod async_read {
 
     pub(crate) const NAME: &[&str] = &["tokio03::AsyncRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
             trait AsyncRead {
                 fn poll_read(
@@ -39,7 +41,8 @@ pub(crate) mod async_seek {
 
     pub(crate) const NAME: &[&str] = &["tokio03::AsyncSeek"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncSeek), None, parse_quote! {
             trait AsyncSeek {
                 fn start_seek(
@@ -60,7 +63,8 @@ pub(crate) mod async_write {
 
     pub(crate) const NAME: &[&str] = &["tokio03::AsyncWrite"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
             trait AsyncWrite {
                 fn poll_write(

--- a/src/derive/external/tokio1.rs
+++ b/src/derive/external/tokio1.rs
@@ -1,92 +1,215 @@
 pub(crate) mod async_buf_read {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio1::AsyncBufRead"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncBufRead), None, parse_quote! {
-            trait AsyncBufRead {
-                fn poll_fill_buf<'__a>(
-                    self: ::core::pin::Pin<&'__a mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>>;
-                fn consume(self: ::core::pin::Pin<&mut Self>, amt: usize);
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncBufRead);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncBufRead {}
+        })
+        .build_impl();
+
+        let poll_fill_buf = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_fill_buf(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_fill_buf(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<&[u8]>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_fill_buf,)* }
+                }
             }
-        }))
+        });
+
+        let consume = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::consume(#pin::new_unchecked(x), amt)));
+        impl_.items.push(parse_quote! {
+            fn consume(self: #pin<&mut Self>, amt: usize) {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#consume,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_read {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio1::AsyncRead"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
-            trait AsyncRead {
-                fn poll_read(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    buf: &mut ::tokio::io::ReadBuf<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncRead);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncRead {}
+        })
+        .build_impl();
+
+        let poll_read = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_read(#pin::new_unchecked(x), cx, buf)));
+        impl_.items.push(parse_quote! {
+            fn poll_read(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                buf: &mut ::tokio::io::ReadBuf<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_read,)* }
+                }
             }
-        }))
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_seek {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio1::AsyncSeek"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncSeek), None, parse_quote! {
-            trait AsyncSeek {
-                fn start_seek(
-                    self: ::core::pin::Pin<&mut Self>,
-                    pos: ::std::io::SeekFrom,
-                ) -> ::std::io::Result<()>;
-                fn poll_complete(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<u64>>;
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncSeek);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait AsyncSeek {}
+        })
+        .build_impl();
+
+        let start_seek = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::start_seek(#pin::new_unchecked(x), pos)));
+        impl_.items.push(parse_quote! {
+            fn start_seek(
+                self: #pin<&mut Self>,
+                pos: ::std::io::SeekFrom,
+            ) -> ::std::io::Result<()> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#start_seek,)* }
+                }
             }
-        }))
+        });
+
+        let poll_complete = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_complete(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_complete(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<u64>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_complete,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }
 
 pub(crate) mod async_write {
+    use quote::ToTokens;
+
     use crate::derive::*;
 
     pub(crate) const NAME: &[&str] = &["tokio1::AsyncWrite"];
 
     pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
         cx.needs_pin_projection();
-        Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::tokio::io::AsyncWrite);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
             trait AsyncWrite {
-                fn poll_write(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    buf: &[u8],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
-                fn poll_flush(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
-                fn poll_shutdown(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                ) -> ::core::task::Poll<::std::io::Result<()>>;
-                fn poll_write_vectored(
-                    self: ::core::pin::Pin<&mut Self>,
-                    cx: &mut ::core::task::Context<'_>,
-                    bufs: &[::std::io::IoSlice<'_>],
-                ) -> ::core::task::Poll<::std::io::Result<usize>>;
                 fn is_write_vectored(&self) -> bool;
             }
-        }))
+        })
+        .build_impl();
+
+        let poll_write = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_write(#pin::new_unchecked(x), cx, buf)));
+        impl_.items.push(parse_quote! {
+            fn poll_write(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                buf: &[u8],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_write,)* }
+                }
+            }
+        });
+
+        let poll_flush = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_flush(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_flush(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_flush,)* }
+                }
+            }
+        });
+
+        let poll_shutdown = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_shutdown(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_shutdown(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<::std::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_shutdown,)* }
+                }
+            }
+        });
+
+        let poll_write_vectored = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_write_vectored(#pin::new_unchecked(x), cx, bufs)));
+        impl_.items.push(parse_quote! {
+            fn poll_write_vectored(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+                bufs: &[::std::io::IoSlice<'_>],
+            ) -> ::core::task::Poll<::std::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_write_vectored,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
     }
 }

--- a/src/derive/external/tokio1.rs
+++ b/src/derive/external/tokio1.rs
@@ -3,7 +3,8 @@ pub(crate) mod async_buf_read {
 
     pub(crate) const NAME: &[&str] = &["tokio1::AsyncBufRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncBufRead), None, parse_quote! {
             trait AsyncBufRead {
                 fn poll_fill_buf<'__a>(
@@ -21,7 +22,8 @@ pub(crate) mod async_read {
 
     pub(crate) const NAME: &[&str] = &["tokio1::AsyncRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncRead), None, parse_quote! {
             trait AsyncRead {
                 fn poll_read(
@@ -39,7 +41,8 @@ pub(crate) mod async_seek {
 
     pub(crate) const NAME: &[&str] = &["tokio1::AsyncSeek"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncSeek), None, parse_quote! {
             trait AsyncSeek {
                 fn start_seek(
@@ -60,7 +63,8 @@ pub(crate) mod async_write {
 
     pub(crate) const NAME: &[&str] = &["tokio1::AsyncWrite"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
         Ok(derive_trait(data, parse_quote!(::tokio::io::AsyncWrite), None, parse_quote! {
             trait AsyncWrite {
                 fn poll_write(

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -11,3 +11,5 @@ use derive_utils::{derive_trait, EnumData as Data};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_quote, Result};
+
+use crate::enum_derive::DeriveContext as Context;

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod external;
 pub(crate) mod std;
 pub(crate) mod ty_impls;
 
-use derive_utils::{derive_trait, EnumData as Data};
+use derive_utils::{derive_trait, EnumData as Data, EnumImpl};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_quote, Result};

--- a/src/derive/std/error.rs
+++ b/src/derive/std/error.rs
@@ -4,7 +4,7 @@ use crate::derive::*;
 
 pub(crate) const NAME: &[&str] = &["Error"];
 
-pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
     let ident = &data.ident;
     let source =
         data.variant_idents().map(|v| quote!(#ident::#v(x) => ::std::option::Option::Some(x)));

--- a/src/derive/std/io.rs
+++ b/src/derive/std/io.rs
@@ -3,7 +3,7 @@ pub(crate) mod read {
 
     pub(crate) const NAME: &[&str] = &["Read", "io::Read"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         #[cfg(auto_enums_no_iovec)]
         let vectored = quote!();
         #[cfg(not(auto_enums_no_iovec))]
@@ -44,7 +44,7 @@ pub(crate) mod buf_read {
 
     pub(crate) const NAME: &[&str] = &["BufRead", "io::BufRead"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::std::io::BufRead), None, parse_quote! {
             trait BufRead {
                 #[inline]
@@ -71,7 +71,7 @@ pub(crate) mod seek {
 
     pub(crate) const NAME: &[&str] = &["Seek", "io::Seek"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         Ok(derive_trait(data, parse_quote!(::std::io::Seek), None, parse_quote! {
             trait Seek {
                 #[inline]
@@ -86,7 +86,7 @@ pub(crate) mod write {
 
     pub(crate) const NAME: &[&str] = &["Write", "io::Write"];
 
-    pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+    pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
         #[cfg(auto_enums_no_iovec)]
         let vectored = quote!();
         #[cfg(not(auto_enums_no_iovec))]

--- a/src/derive/ty_impls/transpose.rs
+++ b/src/derive/ty_impls/transpose.rs
@@ -8,7 +8,7 @@ use crate::derive::*;
 pub(crate) const NAME: &[&str] = &["Transpose"];
 
 // Implementing this with `Into` requires many type annotations.
-pub(crate) fn derive(data: &Data) -> Result<TokenStream> {
+pub(crate) fn derive(_cx: &Context, data: &Data) -> Result<TokenStream> {
     check_fields(data)?;
     let mut items = TokenStream::new();
     items.extend(transpose_option(data));

--- a/src/derive/ty_impls/transpose.rs
+++ b/src/derive/ty_impls/transpose.rs
@@ -67,7 +67,6 @@ fn transpose_result(data: &Data) -> TokenStream {
     let transpose = data
         .variant_idents()
         .map(|v| quote!(#ident::#v(x) => x.map(#ident::#v).map_err(#ident::#v)));
-
     impl_.push_item(parse_quote! {
         #[inline]
         fn transpose(

--- a/tests/auto_enum.rs
+++ b/tests/auto_enum.rs
@@ -13,7 +13,8 @@
     clippy::let_and_return,
     clippy::needless_return,
     clippy::never_loop,
-    clippy::unnecessary_wraps
+    clippy::unnecessary_wraps,
+    clippy::pedantic
 )]
 
 use core::iter;

--- a/tests/enum_derive.rs
+++ b/tests/enum_derive.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(feature = "generator_trait", feature(generator_trait))]
 #![cfg_attr(feature = "fn_traits", feature(fn_traits, unboxed_closures))]
 #![cfg_attr(feature = "trusted_len", feature(trusted_len))]
-#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 #![allow(dead_code)]
 

--- a/tests/enum_derive.rs
+++ b/tests/enum_derive.rs
@@ -4,6 +4,8 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 #![allow(dead_code)]
 
+// See tests/run-pass for external crates.
+
 use auto_enums::enum_derive;
 
 #[test]

--- a/tests/expand/external/futures/async_buf_read.expanded.rs
+++ b/tests/expand/external/futures/async_buf_read.expanded.rs
@@ -51,4 +51,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/futures/async_buf_read.expanded.rs
+++ b/tests/expand/external/futures/async_buf_read.expanded.rs
@@ -3,17 +3,16 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::futures::io::AsyncBufRead for Enum<A, B>
 where
     A: ::futures::io::AsyncBufRead,
     B: ::futures::io::AsyncBufRead,
 {
     #[inline]
-    fn poll_fill_buf<'__a>(
-        self: ::core::pin::Pin<&'__a mut Self>,
+    fn poll_fill_buf(
+        self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
-    ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>> {
+    ) -> ::core::task::Poll<::std::io::Result<&[u8]>> {
         unsafe {
             match self.get_unchecked_mut() {
                 Enum::A(x) => {

--- a/tests/expand/external/futures/async_read.expanded.rs
+++ b/tests/expand/external/futures/async_read.expanded.rs
@@ -3,7 +3,6 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::futures::io::AsyncRead for Enum<A, B>
 where
     A: ::futures::io::AsyncRead,

--- a/tests/expand/external/futures/async_read.expanded.rs
+++ b/tests/expand/external/futures/async_read.expanded.rs
@@ -60,4 +60,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/futures/async_seek.expanded.rs
+++ b/tests/expand/external/futures/async_seek.expanded.rs
@@ -3,7 +3,6 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::futures::io::AsyncSeek for Enum<A, B>
 where
     A: ::futures::io::AsyncSeek,

--- a/tests/expand/external/futures/async_seek.expanded.rs
+++ b/tests/expand/external/futures/async_seek.expanded.rs
@@ -35,4 +35,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/futures/async_write.expanded.rs
+++ b/tests/expand/external/futures/async_write.expanded.rs
@@ -3,7 +3,6 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::futures::io::AsyncWrite for Enum<A, B>
 where
     A: ::futures::io::AsyncWrite,

--- a/tests/expand/external/futures/async_write.expanded.rs
+++ b/tests/expand/external/futures/async_write.expanded.rs
@@ -104,4 +104,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/futures/sink.expanded.rs
+++ b/tests/expand/external/futures/sink.expanded.rs
@@ -99,4 +99,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/futures/sink.expanded.rs
+++ b/tests/expand/external/futures/sink.expanded.rs
@@ -3,7 +3,6 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B, Item> ::futures::sink::Sink<Item> for Enum<A, B>
 where
     A: ::futures::sink::Sink<Item>,

--- a/tests/expand/external/futures/stream.expanded.rs
+++ b/tests/expand/external/futures/stream.expanded.rs
@@ -40,4 +40,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/futures/stream.expanded.rs
+++ b/tests/expand/external/futures/stream.expanded.rs
@@ -3,13 +3,19 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::futures::stream::Stream for Enum<A, B>
 where
     A: ::futures::stream::Stream,
     B: ::futures::stream::Stream<Item = <A as ::futures::stream::Stream>::Item>,
 {
     type Item = <A as ::futures::stream::Stream>::Item;
+    #[inline]
+    fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
+        match self {
+            Enum::A(x) => ::futures::stream::Stream::size_hint(x),
+            Enum::B(x) => ::futures::stream::Stream::size_hint(x),
+        }
+    }
     #[inline]
     fn poll_next(
         self: ::core::pin::Pin<&mut Self>,
@@ -30,13 +36,6 @@ where
                     )
                 }
             }
-        }
-    }
-    #[inline]
-    fn size_hint(&self) -> (usize, ::core::option::Option<usize>) {
-        match self {
-            Enum::A(x) => ::futures::stream::Stream::size_hint(x),
-            Enum::B(x) => ::futures::stream::Stream::size_hint(x),
         }
     }
 }

--- a/tests/expand/external/tokio/async_buf_read.expanded.rs
+++ b/tests/expand/external/tokio/async_buf_read.expanded.rs
@@ -4,16 +4,15 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::tokio::io::AsyncBufRead for Enum<A, B>
 where
     A: ::tokio::io::AsyncBufRead,
     B: ::tokio::io::AsyncBufRead,
 {
-    fn poll_fill_buf<'__a>(
-        self: ::core::pin::Pin<&'__a mut Self>,
+    fn poll_fill_buf(
+        self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
-    ) -> ::core::task::Poll<::std::io::Result<&'__a [u8]>> {
+    ) -> ::core::task::Poll<::std::io::Result<&[u8]>> {
         unsafe {
             match self.get_unchecked_mut() {
                 Enum::A(x) => {

--- a/tests/expand/external/tokio/async_buf_read.expanded.rs
+++ b/tests/expand/external/tokio/async_buf_read.expanded.rs
@@ -50,4 +50,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/tokio/async_read.expanded.rs
+++ b/tests/expand/external/tokio/async_read.expanded.rs
@@ -35,4 +35,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/tokio/async_read.expanded.rs
+++ b/tests/expand/external/tokio/async_read.expanded.rs
@@ -4,7 +4,6 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::tokio::io::AsyncRead for Enum<A, B>
 where
     A: ::tokio::io::AsyncRead,

--- a/tests/expand/external/tokio/async_seek.expanded.rs
+++ b/tests/expand/external/tokio/async_seek.expanded.rs
@@ -4,7 +4,6 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::tokio::io::AsyncSeek for Enum<A, B>
 where
     A: ::tokio::io::AsyncSeek,

--- a/tests/expand/external/tokio/async_seek.expanded.rs
+++ b/tests/expand/external/tokio/async_seek.expanded.rs
@@ -53,4 +53,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/external/tokio/async_write.expanded.rs
+++ b/tests/expand/external/tokio/async_write.expanded.rs
@@ -4,12 +4,17 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::tokio::io::AsyncWrite for Enum<A, B>
 where
     A: ::tokio::io::AsyncWrite,
     B: ::tokio::io::AsyncWrite,
 {
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            Enum::A(x) => ::tokio::io::AsyncWrite::is_write_vectored(x),
+            Enum::B(x) => ::tokio::io::AsyncWrite::is_write_vectored(x),
+        }
+    }
     fn poll_write(
         self: ::core::pin::Pin<&mut Self>,
         cx: &mut ::core::task::Context<'_>,
@@ -98,12 +103,6 @@ where
                     )
                 }
             }
-        }
-    }
-    fn is_write_vectored(&self) -> bool {
-        match self {
-            Enum::A(x) => ::tokio::io::AsyncWrite::is_write_vectored(x),
-            Enum::B(x) => ::tokio::io::AsyncWrite::is_write_vectored(x),
         }
     }
 }

--- a/tests/expand/external/tokio/async_write.expanded.rs
+++ b/tests/expand/external/tokio/async_write.expanded.rs
@@ -107,4 +107,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/std/future.expanded.rs
+++ b/tests/expand/std/future.expanded.rs
@@ -27,4 +27,15 @@ where
         }
     }
 }
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
 fn main() {}

--- a/tests/expand/std/future.expanded.rs
+++ b/tests/expand/std/future.expanded.rs
@@ -3,7 +3,6 @@ enum Enum<A, B> {
     A(A),
     B(B),
 }
-#[allow(unsafe_code)]
 impl<A, B> ::core::future::Future for Enum<A, B>
 where
     A: ::core::future::Future,


### PR DESCRIPTION
If a user creates their own `Unpin` or `Drop` implementation, trait implementations with `Pin<&mut self>` receiver can cause unsoundness.

This was not a problem in `#[auto_enum]` attribute where enums are anonymized, but it becomes a problem when users have access to enums (i.e., when using `#[enum_derive]`).

This is essentially a problem of `derive_utils`, the backend of the derive implementation of this crate, and I was investigating ways to fix it on the `derive_utils` side, but finally decided it would be difficult and removed support for the `Pin<&mut self>` receiver from `derive_utils`. (https://github.com/taiki-e/derive_utils/pull/41)

So, we ensure safety here by an `Unpin` implementation that implements `Unpin` only if all fields are `Unpin` (this also forbids custom `Unpin` implementation), and a hack that forbids custom `Drop` implementation. (Both are what `pin-project` does by default.) The `repr(packed)` check is unnecessary since `repr(packed)` is unavailable on enum.

This would make it impossible to use together with `#[pin_project]` or `pin_project!`, or to create custom `Drop` or `Unpin` implementations -- If someone needs it, it is possible to add an option like use_pin_project to support them, so please leave a comment.