### PR TITLE
Add support for http-body v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add support for `http_body1::Body`.
+
 ## [0.8.3] - 2023-10-21
 
 - Update to [new coroutine API since nightly-2023-10-21](https://github.com/rust-lang/rust/pull/116958). This renames unstable `generator_trait` feature to `coroutine_trait`. The old cargo feature name is kept as a deprecated alias and will be removed in the next breaking release. ([daf9165](https://github.com/taiki-e/auto_enums/commit/daf91653b925d53cde57b598f0d884fe35a53c60))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ tokio03 = []
 tokio02 = []
 # https://docs.rs/tokio/0.1
 tokio01 = []
+# https://docs.rs/http-body/1
+http_body1 = []
 
 # ==============================================================================
 # Unstable features
@@ -98,6 +100,7 @@ tokio02_crate = { package = "tokio", version = "0.2", default-features = false }
 tokio01_crate = { package = "tokio", version = "0.1", default-features = false, features = ["io"] }
 rayon_crate = { package = "rayon", version = "1" }
 serde_crate = { package = "serde", version = "1" }
+http_body1_crate = { package = "http-body", version = "1", default-features = false }
 
 [lints]
 workspace = true

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ traits to `#[derive]`.
 
 `#[enum_derive]` supports many of the standard library traits and some popular
 third-party libraries traits such as [rayon], [futures][futures03],
-[tokio][tokio1]. **See [documentation](https://docs.rs/auto_enums/latest/auto_enums/#supported-traits) for a complete list of supported traits.**
+[tokio][tokio1], [http_body][http_body1]. **See [documentation](https://docs.rs/auto_enums/latest/auto_enums/#supported-traits) for a complete list of supported traits.**
 
 If you want to use traits that are not supported by `#[enum_derive]`, you
 can use another crate that provides [derives macros][proc-macro-derive], or
@@ -165,6 +165,8 @@ enum Foo<A, B> {
 - **`trusted_len`**
   - Enable to use `[std|core]::iter::TrustedLen` trait.
   - Note that this feature is unstable and may cause incompatible changes between patch versions.
+- **`http_body1`**
+  - Enable to use [http_body v1][http_body1] traits.
 
 ### `type_analysis` feature
 
@@ -218,6 +220,7 @@ Please be careful if you return another traits with the same name.
 [tokio02]: https://docs.rs/tokio/0.2
 [tokio03]: https://docs.rs/tokio/0.3
 [tokio1]: https://docs.rs/tokio/1
+[http_body1]: https://docs.rs/http_body/1
 
 ## License
 

--- a/src/derive/external/http_body1.rs
+++ b/src/derive/external/http_body1.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+pub(crate) mod body {
+    use quote::ToTokens;
+
+    use crate::derive::*;
+
+    pub(crate) const NAME: &[&str] = &["http_body1::Body"];
+
+    pub(crate) fn derive(cx: &Context, data: &Data) -> Result<TokenStream> {
+        cx.needs_pin_projection();
+
+        let ident = &data.ident;
+        let pin = quote!(::core::pin::Pin);
+        let trait_: syn::Path = parse_quote!(::http_body::Body);
+        let mut impl_ = EnumImpl::from_trait(data, trait_.clone(), None, parse_quote! {
+            trait Body {
+                type Data;
+                type Error;
+                #[inline]
+                fn is_end_stream(&self) -> bool;
+                #[inline]
+                fn size_hint(&self) -> ::http_body::SizeHint;
+            }
+        })
+        .build_impl();
+
+        let poll_frame = data
+            .variant_idents()
+            .map(|v| quote!(#ident::#v(x) => #trait_::poll_frame(#pin::new_unchecked(x), cx)));
+        impl_.items.push(parse_quote! {
+            fn poll_frame(
+                self: #pin<&mut Self>,
+                cx: &mut ::core::task::Context<'_>,
+            ) -> ::core::task::Poll<
+                ::core::option::Option<
+                    ::core::result::Result<::http_body::Frame<Self::Data>, Self::Error>,
+                >,
+            > {
+                unsafe {
+                    match self.get_unchecked_mut() { #(#poll_frame,)* }
+                }
+            }
+        });
+
+        Ok(impl_.into_token_stream())
+    }
+}

--- a/src/derive/external/mod.rs
+++ b/src/derive/external/mod.rs
@@ -24,3 +24,6 @@ pub(crate) mod tokio03;
 // https://docs.rs/tokio/1
 #[cfg(feature = "tokio1")]
 pub(crate) mod tokio1;
+// https://docs.rs/http-body/1
+#[cfg(feature = "http_body1")]
+pub(crate) mod http_body1;

--- a/src/enum_derive.rs
+++ b/src/enum_derive.rs
@@ -164,6 +164,9 @@ fn get_derive(s: &str) -> Option<DeriveFn> {
         external::tokio01::async_read,
         #[cfg(feature = "tokio01")]
         external::tokio01::async_write,
+        // http_body1
+        #[cfg(feature = "http_body1")]
+        external::http_body1::body,
     }
 
     None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -735,6 +735,10 @@ fn func(x: i32) -> impl ParallelIterator {
 - [`tokio01::AsyncRead`](https://docs.rs/tokio/0.1/tokio/io/trait.AsyncRead.html)
 - [`tokio01::AsyncWrite`](https://docs.rs/tokio/0.1/tokio/io/trait.AsyncWrite.html)
 
+### [http_body v1][http_body1] *(requires `"http_body1"` crate feature)*
+
+- [`http_body1::Body`](https://docs.rs/http-body/1/http_body/trait.Body.html) - [example](https://github.com/taiki-e/auto_enums/blob/HEAD/tests/expand/external/http_body/body.rs) | [generated code](https://github.com/taiki-e/auto_enums/blob/HEAD/tests/expand/external/http_body/body.expanded.rs)
+
 ## Inherent methods
 
 These don't derive traits, but derive inherent methods instead.
@@ -859,6 +863,7 @@ Please be careful if you return another traits with the same name.
 [tokio02]: https://docs.rs/tokio/0.2
 [tokio03]: https://docs.rs/tokio/0.3
 [tokio1]: https://docs.rs/tokio/1
+[http_body1]: https://docs.rs/http-body/1
 */
 
 #![doc(test(

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -14,6 +14,7 @@
     feature = "tokio02",
     feature = "tokio03",
     feature = "tokio1",
+    feature = "http_body1",
 ))]
 
 #[rustversion::attr(not(nightly), ignore)]

--- a/tests/expand/external/http_body/body.expanded.rs
+++ b/tests/expand/external/http_body/body.expanded.rs
@@ -1,0 +1,62 @@
+extern crate http_body1_crate as http_body;
+use auto_enums::enum_derive;
+enum Enum<A, B> {
+    A(A),
+    B(B),
+}
+impl<A, B> ::http_body::Body for Enum<A, B>
+where
+    A: ::http_body::Body,
+    B: ::http_body::Body<
+        Data = <A as ::http_body::Body>::Data,
+        Error = <A as ::http_body::Body>::Error,
+    >,
+{
+    type Data = <A as ::http_body::Body>::Data;
+    type Error = <A as ::http_body::Body>::Error;
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        match self {
+            Enum::A(x) => ::http_body::Body::is_end_stream(x),
+            Enum::B(x) => ::http_body::Body::is_end_stream(x),
+        }
+    }
+    #[inline]
+    fn size_hint(&self) -> ::http_body::SizeHint {
+        match self {
+            Enum::A(x) => ::http_body::Body::size_hint(x),
+            Enum::B(x) => ::http_body::Body::size_hint(x),
+        }
+    }
+    fn poll_frame(
+        self: ::core::pin::Pin<&mut Self>,
+        cx: &mut ::core::task::Context<'_>,
+    ) -> ::core::task::Poll<
+        ::core::option::Option<
+            ::core::result::Result<::http_body::Frame<Self::Data>, Self::Error>,
+        >,
+    > {
+        unsafe {
+            match self.get_unchecked_mut() {
+                Enum::A(x) => {
+                    ::http_body::Body::poll_frame(::core::pin::Pin::new_unchecked(x), cx)
+                }
+                Enum::B(x) => {
+                    ::http_body::Body::poll_frame(::core::pin::Pin::new_unchecked(x), cx)
+                }
+            }
+        }
+    }
+}
+impl<A, B> ::core::marker::Unpin for Enum<A, B>
+where
+    A: ::core::marker::Unpin,
+    B: ::core::marker::Unpin,
+{}
+const _: () = {
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+    impl<A, B> MustNotImplDrop for Enum<A, B> {}
+};
+fn main() {}

--- a/tests/expand/external/http_body/body.rs
+++ b/tests/expand/external/http_body/body.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+extern crate http_body1_crate as http_body;
+
+use auto_enums::enum_derive;
+
+#[enum_derive(http_body1::Body)]
+enum Enum<A, B> {
+    A(A),
+    B(B),
+}
+
+fn main() {}

--- a/tests/run-pass/http_body1.rs
+++ b/tests/run-pass/http_body1.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+extern crate http_body1_crate as http_body;
+
+use auto_enums::enum_derive;
+
+#[enum_derive(http_body1::Body)]
+enum HttpBody1<A, B> {
+    A(A),
+    B(B),
+}
+
+fn main() {}


### PR DESCRIPTION
closes https://github.com/taiki-e/auto_enums/issues/160

## `http_body::Body` trait
* https://docs.rs/http-body/1.0.0/http_body/trait.Body.html

## Example 1

```rs
use auto_enums::auto_enum;
use http_body_util::BodyExt as _;
use std::convert::Infallible;
use std::net::SocketAddr;

#[auto_enum(http_body1::Body)]
fn create_body(
    req: hyper::Request<hyper::body::Incoming>,
) -> impl hyper::body::Body<Data = hyper::body::Bytes, Error = hyper::Error> {
    match req.method() {
        // "hello world"
        &hyper::Method::GET => {
            let body: http_body_util::combinators::BoxBody<hyper::body::Bytes, hyper::Error> =
                http_body_util::Full::new(hyper::body::Bytes::from("Hello, World!\n"))
                    .map_err(|_: Infallible| unreachable!())
                    .boxed();
            body
        }
        // Response body is request body (echo-like)
        _ => {
            let body: hyper::body::Incoming = req.into_body();
            body
        }
    }
}
async fn handle(
    req: hyper::Request<hyper::body::Incoming>,
) -> Result<
    hyper::Response<impl hyper::body::Body<Data = hyper::body::Bytes, Error = hyper::Error>>,
    Infallible,
> {
    Ok(hyper::Response::new(create_body(req)))
}

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
    let tcp_listener = tokio::net::TcpListener::bind(addr).await?;
    loop {
        let (stream, _) = tcp_listener.accept().await?;
        tokio::task::spawn(async move {
            if let Err(err) = hyper::server::conn::http1::Builder::new()
                .serve_connection(
                    hyper_util::rt::TokioIo::new(stream),
                    hyper::service::service_fn(handle),
                )
                .await
            {
                println!("Error serving connection: {:?}", err);
            }
        });
    }
}
```

```console
$ curl localhost:3000
Hello, World!

$ curl --data "this message should be echoed" localhost:3000
this message should be echoed
```

## Limitation?

I tried to use `hyper::Response<impl Body<...>>` as return type but a compile error ocurred.

```rs
// compile error code

#[auto_enum(http_body1::Body)]
async fn handle(
    req: hyper::Request<hyper::body::Incoming>,
) -> hyper::Response<impl hyper::body::Body<Data = hyper::body::Bytes, Error = hyper::Error>> {
    match req.method() {
        // "hello world"
        &Method::GET => {
            let body: http_body_util::combinators::BoxBody<hyper::body::Bytes, hyper::Error> =
                http_body_util::Full::new(hyper::body::Bytes::from("Hello, World!\n"))
                    .map_err(|_: Infallible| unreachable!())
                    .boxed();
            hyper::Response::new(body)
        }
        // Response body is request body (echo-like)
        // Body type is hyper::body::Incoming
        _ => hyper::Response::new(req.into_body()),
    }
}
```

```
28 | #[auto_enum(http_body1::Body)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Response<_>`, found `__Enum6727346999787098788<Response<...>, ...>`
   |
   = note: expected struct `Response<_>`
                found enum `__Enum6727346999787098788<Response<BoxBody<hyper::body::Bytes, hyper::Error>>, _>`
   = note: this error originates in the attribute macro `auto_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Return type of  `hyper::Response<impl Body<...>>` (and `Result<hyper::Response<impl Body<...>>, ...>`) should be a very common ussage in hyper.

<details>
<summary>workaround using enum_derive</summary>

```rs
// works

async fn handle_with_enum_drive(
    req: hyper::Request<hyper::body::Incoming>,
) -> Result<
    hyper::Response<impl hyper::body::Body<Data = hyper::body::Bytes, Error = hyper::Error>>,
    Infallible,
> {
    #[auto_enums::enum_derive(http_body1::Body)]
    enum BodyEnum<B1, B2> {
        Body1(B1),
        Body2(B2),
    }

    match req.method() {
        // "hello world"
        &hyper::Method::GET => {
            let body: http_body_util::combinators::BoxBody<hyper::body::Bytes, hyper::Error> =
                http_body_util::Full::new(hyper::body::Bytes::from("Hello, World!\n"))
                    .map_err(|_: Infallible| unreachable!())
                    .boxed();
            Ok(hyper::Response::new(BodyEnum::Body1(body)))
        }
        // Response body is request body (echo-like)
        // Body type is hyper::body::Incoming
        _ => Ok(hyper::Response::new(BodyEnum::Body2(req.into_body()))),
    }
}
```
</details>

## Limitation? (simple)

```rs
// compile error code

#[auto_enum(Iterator)]
fn foo(x: i32) -> Option<impl Iterator<Item = i32>> {
    match x {
        0 => Some(1..10),
        1 => None,
        _ => Some(vec![5, 10].into_iter()),
    }
}
```

```
62 | #[auto_enum(Iterator)]
   | ^^^^^^^^^^^^^^^^^^^^^^ expected `Option<_>`, found `__Enum375715025964148285<Option<...>, ..., ...>`
63 | fn foo(x: i32) -> Option<impl Iterator<Item = i32>> {
   |                   --------------------------------- expected `Option<_>` because of return type
```

edit: I understand using "?" solves the issue:
https://github.com/taiki-e/auto_enums/blob/f688cc88ad1f8f7dc984fcf16bc15f46386bdc0c/tests/auto_enum.rs#L260-L278


Some marker needed like the following `#[auto_enum] 1..10`? I'm not sure that macro implementation can know `1..10` and `vec[...].into_iter()` implement `Iterator<Item = i32>` and generate code wrapped with `__Enum`.

```rs
// imaginary code

#[auto_enum(Iterator)]
fn foo(x: i32) -> Option<impl Iterator<Item = i32>> {
    match x {
        0 => Some(#[auto_enum] 1..10),
        1 => None,
        _ => Some(#[auto_enum] vec![5, 10].into_iter()),
    }
}
```